### PR TITLE
Fix SFTP/WebDAV integration and improve timesheet UX

### DIFF
--- a/Backend/admin/src/routes/v3/storage/Storage.controller.js
+++ b/Backend/admin/src/routes/v3/storage/Storage.controller.js
@@ -1409,13 +1409,19 @@ class StorageController {
             let insertId = await StorageModel.addStorageData("7", organization_id, user_id)
             await StorageModel.addStorageCreds(insertId.insertId, storage_creds, organization_id, user_id, auto_delete_period, null, note);
             
-            if(req?.file?.path) fs.unlinkSync(req?.file?.path);
-            await SFTPUTILS.deleteCreds(`{organization_id}`);
+            if (req?.file?.path) {
+                try { fs.unlinkSync(req.file.path); } catch (_) { /* already gone */ }
+            }
+            try { await SFTPUTILS.deleteCreds(`${organization_id}`); } catch (_) {}
 
             return sendResponse(res, 200, null, storageMessages.find(x => x.id === "13")[language] || storageMessages.find(x => x.id === "13")["en"], null);
         } catch (error) {
-            fs.unlinkSync(req?.file?.path);
-            await SFTPUTILS.deleteCreds(`{organization_id}`);
+            // Cleanup must not throw — otherwise it masks the real error with a
+            // misleading TypeError ("path argument must be of type string...").
+            if (req?.file?.path) {
+                try { fs.unlinkSync(req.file.path); } catch (_) {}
+            }
+            try { await SFTPUTILS.deleteCreds(`${organization_id}`); } catch (_) {}
             if (error.message === "connect: getConnection: All configured authentication methods failed") {
                 return sendResponse(res, 400, null, storageMessages.find(x => x.id === "32")[language] || storageMessages.find(x => x.id === "32")["en"], error?.message);
             }

--- a/Frontend/src/page/protected/admin/employee-profile/TimesheetsTab.jsx
+++ b/Frontend/src/page/protected/admin/employee-profile/TimesheetsTab.jsx
@@ -8,17 +8,22 @@ import { fetchTimesheets } from "./service";
 import { secToHMS, fmtDateTime } from "@/lib/dateTimeUtils";
 
 const columnDefs = [
-  { key: "clockIn",            labelKey: "clockin",         className: "text-gray-800" },
-  { key: "clockOut",           labelKey: "clockout",        className: "text-gray-800" },
-  { key: "totalHours",         labelKey: "totalHours",      className: "text-gray-800" },
-  { key: "officeHours",        labelKey: "officeHours",     className: "text-gray-800" },
-  { key: "activeHours",        labelKey: "activeHours",     className: "text-gray-800" },
-  { key: "productiveHours",    labelKey: "prodHour",        className: "text-green-600", hasInfo: true },
-  { key: "unproductiveHours",  labelKey: "unProdHour",      className: "text-red-500",   hasInfo: true },
+  { key: "clockIn",            labelKey: "clockin",            className: "text-gray-800" },
+  { key: "clockOut",           labelKey: "clockout",           className: "text-gray-800" },
+  { key: "totalHours",         labelKey: "totalHours",         className: "text-gray-800" },
+  { key: "officeHours",        labelKey: "officeHours",        className: "text-gray-800" },
+  { key: "activeHours",        labelKey: "activeHours",        className: "text-gray-800" },
+  { key: "productiveHours",    labelKey: "prodHour",           className: "text-green-600", hasInfo: true },
+  { key: "unproductiveHours",  labelKey: "unProdHour",         className: "text-red-500",   hasInfo: true },
+  { key: "neutralHours",       labelKey: "ts_neutral",         className: "text-gray-800" },
+  { key: "idleHours",          labelKey: "ts_idle",            className: "text-gray-800" },
+  { key: "offlineHours",       labelKey: "ts_offline",         className: "text-gray-800" },
+  { key: "productivity",       labelKey: "ts_productivity_pct",className: "text-blue-600" },
 ];
 
 // API: { code, data: { user_data: [{start_time, end_time, total_time, office_time,
-//   computer_activities_time, productive_duration, non_productive_duration}] } }
+//   computer_activities_time, productive_duration, non_productive_duration,
+//   neutral_duration, idle_duration, offline, productivity}] } }
 const mapRow = (d) => ({
   clockIn:           fmtDateTime(d.start_time),
   clockOut:          fmtDateTime(d.end_time),
@@ -27,6 +32,10 @@ const mapRow = (d) => ({
   activeHours:       secToHMS(d.computer_activities_time),
   productiveHours:   secToHMS(d.productive_duration),
   unproductiveHours: secToHMS(d.non_productive_duration),
+  neutralHours:      secToHMS(d.neutral_duration),
+  idleHours:         secToHMS(d.idle_duration),
+  offlineHours:      secToHMS(d.offline),
+  productivity:      d.productivity != null ? `${Number(d.productivity).toFixed(2)}%` : "0.00%",
 });
 
 export default function TimesheetsTab({ employee, startDate, endDate }) {
@@ -101,7 +110,8 @@ export default function TimesheetsTab({ employee, startDate, endDate }) {
                     key={col.key}
                     className={`px-4 py-4 text-[13px] text-center whitespace-nowrap ${
                       col.key === "productiveHours"   ? "text-green-600 font-semibold" :
-                      col.key === "unproductiveHours" ? "text-red-500 font-semibold"  : "text-gray-600"
+                      col.key === "unproductiveHours" ? "text-red-500 font-semibold"  :
+                      col.key === "productivity"      ? "text-blue-600 font-semibold" : "text-gray-600"
                     } ${i < columns.length - 1 ? "border-r border-gray-200" : ""}`}
                   >
                     {row[col.key]}

--- a/Frontend/src/page/protected/admin/storage-types/AddStorageModal.jsx
+++ b/Frontend/src/page/protected/admin/storage-types/AddStorageModal.jsx
@@ -14,6 +14,8 @@ import {
   getStorageTypeValueFromName,
   getStorageTypes,
   addStorageData,
+  addSftpIntegration,
+  addWebdavIntegration,
   updateStorageData,
 } from "./service";
 
@@ -114,7 +116,9 @@ export default function AddStorageModal({ open, onOpenChange, editItem, onSucces
       return;
     }
     for (const field of fields) {
-      if (!formValues[field.key]?.trim()) {
+      if (field.optional) continue;
+      if (field.type === "file") continue;
+      if (!String(formValues[field.key] ?? "").trim()) {
         setError(`${field.label} ${t("storage_field_required")}`);
         return;
       }
@@ -123,23 +127,47 @@ export default function AddStorageModal({ open, onOpenChange, editItem, onSucces
     setSaving(true);
     setError("");
 
-    const payload = { storage_type_id: providerId, ...formValues, note };
-
     let result;
     if (isEdit) {
-      payload.storage_data_id = editItem.storage_data_id;
+      const payload = { storage_type_id: providerId, ...formValues, note, storage_data_id: editItem.storage_data_id };
+      // File field can't be edited in-place via JSON update endpoint; strip it.
+      delete payload.pemFile;
       result = await updateStorageData(payload);
+    } else if (storageType === "sftp") {
+      result = await addSftpIntegration({
+        host: formValues.host,
+        username: formValues.username,
+        password: formValues.password,
+        port: formValues.port,
+        ftp_path: formValues.ftp_path,
+        auto_delete_period: formValues.auto_delete_period,
+        pemFile: formValues.pemFile,
+        note,
+      });
+    } else if (storageType === "webdav") {
+      result = await addWebdavIntegration({
+        storage_type_id: providerId,
+        baseUrl: formValues.baseUrl,
+        webdav_path: formValues.webdav_path,
+        username: formValues.username,
+        password: formValues.password,
+        auto_delete_period: formValues.auto_delete_period,
+        note,
+      });
     } else {
+      const payload = { storage_type_id: providerId, ...formValues, note };
       result = await addStorageData(payload);
     }
 
     setSaving(false);
 
-    if (result) {
-      onSuccess?.();
+    if (result?.ok) {
+      onSuccess?.(result.message);
       handleClose();
     } else {
-      setError(t("storage_save_failed"));
+      // Show the backend's message inside the modal so the user can correct
+      // the input without losing what they typed.
+      setError(result?.message || t("storage_save_failed"));
     }
   };
 
@@ -187,39 +215,49 @@ export default function AddStorageModal({ open, onOpenChange, editItem, onSucces
           {fields.map((field) => (
             <div key={field.key}>
               <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
-                {field.label} <span className="text-red-500">*</span>
+                {field.label}{!field.optional && <span className="text-red-500"> *</span>}
               </label>
-              <div className="relative">
+              {field.type === "file" ? (
                 <Input
-                  type={
-                    field.type === "password" && !showPassword[field.key]
-                      ? "password"
-                      : "text"
-                  }
-                  value={formValues[field.key] ?? ""}
-                  onChange={(e) => handleFieldChange(field.key, e.target.value)}
-                  placeholder={`${t("storage_enter_prefix")} ${field.label}`}
-                  className="h-10 text-[13px] pr-10"
+                  type="file"
+                  accept={field.accept}
+                  onChange={(e) => handleFieldChange(field.key, e.target.files?.[0] ?? null)}
+                  disabled={isEdit}
+                  className="h-10 text-[13px] file:mr-3 file:rounded-md file:border-0 file:bg-blue-50 file:px-3 file:py-1.5 file:text-blue-700"
                 />
-                {field.type === "password" && (
-                  <button
-                    type="button"
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
-                    onClick={() =>
-                      setShowPassword((prev) => ({
-                        ...prev,
-                        [field.key]: !prev[field.key],
-                      }))
+              ) : (
+                <div className="relative">
+                  <Input
+                    type={
+                      field.type === "password" && !showPassword[field.key]
+                        ? "password"
+                        : "text"
                     }
-                  >
-                    {showPassword[field.key] ? (
-                      <EyeOff size={15} />
-                    ) : (
-                      <Eye size={15} />
-                    )}
-                  </button>
-                )}
-              </div>
+                    value={formValues[field.key] ?? ""}
+                    onChange={(e) => handleFieldChange(field.key, e.target.value)}
+                    placeholder={`${t("storage_enter_prefix")} ${field.label}`}
+                    className="h-10 text-[13px] pr-10"
+                  />
+                  {field.type === "password" && (
+                    <button
+                      type="button"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                      onClick={() =>
+                        setShowPassword((prev) => ({
+                          ...prev,
+                          [field.key]: !prev[field.key],
+                        }))
+                      }
+                    >
+                      {showPassword[field.key] ? (
+                        <EyeOff size={15} />
+                      ) : (
+                        <Eye size={15} />
+                      )}
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
           ))}
 

--- a/Frontend/src/page/protected/admin/storage-types/StorageType.jsx
+++ b/Frontend/src/page/protected/admin/storage-types/StorageType.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Settings, ChevronDown, Plus, Trash2, CheckCircle } from "lucide-react";
+import { Settings, ChevronDown, Plus, Trash2 } from "lucide-react";
+import Swal from "sweetalert2";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -45,18 +46,26 @@ export default function StorageType() {
   const [deleteItem, setDeleteItem] = useState(null);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [actionLoading, setActionLoading] = useState(false);
-  const [successMsg, setSuccessMsg] = useState("");
-  const [errorMsg, setErrorMsg] = useState("");
 
-  const showSuccess = (msg) => {
-    setSuccessMsg(msg);
-    setTimeout(() => setSuccessMsg(""), 3000);
-  };
+  const showSuccess = (msg) =>
+    Swal.fire({
+      icon: "success",
+      title: t("success") || "Success",
+      text: msg,
+      timer: 2500,
+      showConfirmButton: false,
+      toast: true,
+      position: "top-end",
+    });
 
-  const showError = (msg) => {
-    setErrorMsg(msg);
-    setTimeout(() => setErrorMsg(""), 4000);
-  };
+  const showError = (msg) =>
+    Swal.fire({
+      icon: "error",
+      title: t("error") || "Error",
+      text: msg,
+      showConfirmButton: true,
+      confirmButtonColor: "#ef4444",
+    });
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -81,8 +90,8 @@ export default function StorageType() {
     if (!isOpen) setEditItem(null);
   };
 
-  const handleSaveSuccess = () => {
-    showSuccess(editItem ? t("storage_updated_success") : t("storage_added_success"));
+  const handleSaveSuccess = (backendMsg) => {
+    showSuccess(backendMsg || (editItem ? t("storage_updated_success") : t("storage_added_success")));
     loadData();
   };
 
@@ -98,11 +107,11 @@ export default function StorageType() {
     setActionLoading(false);
     setDeleteConfirmOpen(false);
     setDeleteItem(null);
-    if (result) {
-      showSuccess(t("storage_deleted_success"));
+    if (result.ok) {
+      showSuccess(result.message || t("storage_deleted_success"));
       loadData();
     } else {
-      showError(t("storage_delete_failed"));
+      showError(result.message || t("storage_delete_failed"));
     }
   };
 
@@ -110,11 +119,11 @@ export default function StorageType() {
     setActionLoading(true);
     const result = await updateStorageOption(item.storage_data_id);
     setActionLoading(false);
-    if (result) {
-      showSuccess(t("storage_activated_success"));
+    if (result.ok) {
+      showSuccess(result.message || t("storage_activated_success"));
       loadData();
     } else {
-      showError(t("storage_activate_failed"));
+      showError(result.message || t("storage_activate_failed"));
     }
   };
 
@@ -130,19 +139,6 @@ export default function StorageType() {
 
   return (
     <div className="space-y-4">
-      {/* Success / Error banners */}
-      {successMsg && (
-        <div className="flex items-center gap-2 px-4 py-2.5 bg-emerald-50 border border-emerald-200 rounded-lg text-sm text-emerald-700">
-          <CheckCircle size={15} />
-          {successMsg}
-        </div>
-      )}
-      {errorMsg && (
-        <div className="px-4 py-2.5 bg-red-50 border border-red-200 rounded-lg text-sm text-red-600">
-          {errorMsg}
-        </div>
-      )}
-
       {/* Header Card */}
       <div className="emp-card p-4 sm:p-5">
         <div className="flex flex-col sm:flex-row sm:items-center gap-4">

--- a/Frontend/src/page/protected/admin/storage-types/service.js
+++ b/Frontend/src/page/protected/admin/storage-types/service.js
@@ -1,5 +1,24 @@
 import apiService from "@/services/api.service";
 
+// ─── Result shape helper ─────────────────────────────────────────────────────
+// All write/mutation services return { ok, message, data } so the caller can
+// always show a Swal with the backend-provided text (success or error).
+// Backend response shape: { code, data, message, error }
+const ok = (resp) => ({
+  ok: true,
+  message: resp?.message || "Success",
+  data: resp?.data ?? null,
+});
+const fail = (error, fallback = "Something went wrong") => ({
+  ok: false,
+  message:
+    error?.response?.data?.message ||
+    error?.response?.data?.error ||
+    error?.message ||
+    fallback,
+  data: null,
+});
+
 // ─── Storage field definitions per type ──────────────────────────────────────
 // Keys match the flat field names returned by the API response.
 
@@ -69,18 +88,21 @@ export const STORAGE_FIELD_CONFIG = {
     { key: "ftp_path",           label: "FTP Path",                     type: "text" },
     { key: "auto_delete_period", label: "Delete Data Older Than (Days)", type: "text" },
   ],
-  // SFTP shares same fields as FTP
+  // SFTP: PHP posts multipart to /storage/add-sftp-integration. PEM file is optional
+  // (backend allows password-only auth). password is also optional in the controller.
   sftp: [
     { key: "host",               label: "Host",                         type: "text" },
     { key: "username",           label: "Username",                     type: "text" },
-    { key: "password",           label: "Password",                     type: "password" },
+    { key: "password",           label: "Password",                     type: "password",  optional: true },
     { key: "port",               label: "Port",                         type: "text" },
     { key: "ftp_path",           label: "FTP Path",                     type: "text" },
+    { key: "pemFile",            label: "PEM Key (optional)",           type: "file",      optional: true, accept: ".pem" },
     { key: "auto_delete_period", label: "Delete Data Older Than (Days)", type: "text" },
   ],
   // editForm: baseUrl→base_url, webdavPath→webdav_path, username, password
+  // Backend /add-webdav-integration reads: baseUrl (camelCase), webdav_path, username, password.
   webdav: [
-    { key: "base_url",           label: "Base URL",                     type: "text" },
+    { key: "baseUrl",            label: "Base URL",                     type: "text" },
     { key: "webdav_path",        label: "WebDAV Path",                  type: "text" },
     { key: "username",           label: "Username",                     type: "text" },
     { key: "password",           label: "Password",                     type: "password" },
@@ -136,20 +158,57 @@ export const getStorageTypes = async () => {
 export const addStorageData = async (payload) => {
   try {
     const { data } = await apiService.apiInstance.post("/storage/add-storage-data", payload);
-    return data ?? null;
+    return ok(data);
   } catch (error) {
     console.error("Storage: addStorageData error", error);
-    return null;
+    return fail(error, "Failed to add storage");
+  }
+};
+
+// SFTP requires multipart/form-data because the backend route is wrapped in
+// multer().single("file"). PEM file is optional — backend falls back to password auth.
+// Mirrors PHP SettingsController::addStorageSFTP — same endpoint, same field names,
+// same multipart parts (no storage_type_id; backend hardcodes "7").
+export const addSftpIntegration = async ({ host, username, password, port, ftp_path, auto_delete_period, note, pemFile }) => {
+  try {
+    const fd = new FormData();
+    fd.append("host", host ?? "");
+    fd.append("username", username ?? "");
+    fd.append("password", password ?? "");
+    fd.append("port", port || "22");
+    fd.append("ftp_path", ftp_path ?? "");
+    fd.append("auto_delete_period", auto_delete_period ?? "");
+    fd.append("note", note ?? "");
+    if (pemFile instanceof File) fd.append("file", pemFile);
+    const { data } = await apiService.apiInstance.post(
+      "/storage/add-sftp-integration",
+      fd,
+      { headers: { "Content-Type": "multipart/form-data" } }
+    );
+    return ok(data);
+  } catch (error) {
+    console.error("Storage: addSftpIntegration error", error);
+    return fail(error, "Failed to add SFTP integration");
+  }
+};
+
+export const addWebdavIntegration = async (payload) => {
+  try {
+    const { data } = await apiService.apiInstance.post("/storage/add-webdav-integration", payload);
+    return ok(data);
+  } catch (error) {
+    console.error("Storage: addWebdavIntegration error", error);
+    return fail(error, "Failed to add WebDAV integration");
   }
 };
 
 export const updateStorageData = async (payload) => {
   try {
     const { data } = await apiService.apiInstance.put("/storage/update-storage-data", payload);
-    return data ?? null;
+    return ok(data);
   } catch (error) {
     console.error("Storage: updateStorageData error", error);
-    return null;
+    return fail(error, "Failed to update storage");
   }
 };
 
@@ -158,10 +217,10 @@ export const deleteStorageData = async (storageDataId) => {
     const { data } = await apiService.apiInstance.delete("/storage/delete-storage-data", {
       data: { storage_data_id: storageDataId },
     });
-    return data ?? null;
+    return ok(data);
   } catch (error) {
     console.error("Storage: deleteStorageData error", error);
-    return null;
+    return fail(error, "Failed to delete storage");
   }
 };
 
@@ -171,9 +230,9 @@ export const updateStorageOption = async (storageDataId) => {
       storage_data_id: storageDataId,
       status: "1",
     });
-    return data ?? null;
+    return ok(data);
   } catch (error) {
     console.error("Storage: updateStorageOption error", error);
-    return null;
+    return fail(error, "Failed to activate storage");
   }
 };

--- a/Frontend/src/page/protected/admin/timesheets/timesheetStore.js
+++ b/Frontend/src/page/protected/admin/timesheets/timesheetStore.js
@@ -12,6 +12,7 @@ import {
 } from "./service";
 
 const today = moment().format("YYYY-MM-DD");
+const sevenDaysAgo = moment().subtract(6, "days").format("YYYY-MM-DD");
 
 // Default visible columns in the table
 const DEFAULT_VISIBLE_COLUMNS = [
@@ -68,7 +69,7 @@ export const useTimesheetStore = create((set, get) => ({
         department: "all",
         employee: "all",
         shift: "all",
-        startDate: today,
+        startDate: sevenDaysAgo,
         endDate: today,
         search: "",
     },


### PR DESCRIPTION
## Summary
- **Backend (SFTP)**: guard `fs.unlinkSync` against undefined `req.file.path` in both success and catch paths so SFTP submissions without a PEM key no longer crash with the misleading `path argument must be of type string... Received undefined` TypeError. Cleanup is wrapped in try/catch so it never masks the real SFTP error.
- **Backend (SFTP)**: fix template literal in `SFTPUTILS.deleteCreds` (`` `{organization_id}` `` → `` `${organization_id}` ``).
- **Frontend (Storage)**: route SFTP to `/storage/add-sftp-integration` as `multipart/form-data` and WebDAV to `/storage/add-webdav-integration` — matches PHP reference and the multer-wrapped backend route. Added optional PEM-key file input.
- **Frontend (Storage)**: services return `{ ok, message, data }`; add/edit/delete/activate now show success/error via SweetAlert2 toasts using backend messages (matches existing patterns in `EmpAlertPolicies`).
- **Frontend (Timesheets)**: admin timesheets default date range is now last 7 days instead of today-only, so the table populates on first load.
- **Frontend (Employee profile)**: `TimesheetsTab` adds Neutral, Idle, Offline, and Productivity % columns to match the global admin timesheet header.

## Test plan
- [ ] Admin → Settings → Storage: add SFTP **without** PEM file — succeeds or returns real auth error (no TypeError).
- [ ] Admin → Settings → Storage: add SFTP **with** `.pem` file — succeeds.
- [ ] Storage list: edit, delete, activate — each shows a Swal toast with the backend message.
- [ ] Admin → Timesheets: page loads with last-7-days range and shows records.
- [ ] Admin → Employee profile → Timesheets tab: shows Neutral / Idle / Offline / Productivity % columns.