### PR TITLE
Fix roles/permissions and monitoring control against PHP reference

### DIFF
--- a/Frontend/src/components/common/monitoring-control/EmpMonitoringControl.jsx
+++ b/Frontend/src/components/common/monitoring-control/EmpMonitoringControl.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next";
 import { Search, Settings, Edit2, Trash2, ChevronDown } from "lucide-react"
+import Swal from "sweetalert2"
 import PaginationComponent from "@/components/common/Pagination"
 import CustomSelect from "@/components/common/elements/CustomSelect"
 import CreateGroup from "@/components/common/monitoring-control/dialog/CreateGroup"
@@ -18,13 +19,13 @@ import {
 import EmpMonitoringControlLogo from "@/assets/settings/monitoring-control.svg"
 import useMonitoringControlStore from "@/page/protected/admin/monitoring-control/monitoringControlStore"
 
-const CUSTOM_PRODUCTIVITY_TIMES = [
-  { label: "06:00", value: "06:00" },
-  { label: "07:00", value: "07:00" },
-  { label: "08:00", value: "08:00" },
-  { label: "09:00", value: "09:00" },
-  { label: "10:00", value: "10:00" },
-]
+// Mirrors PHP groups.blade.php: 01:00–24:00, zero-padded for 1–9 (matches
+// @for($i=1;$i<=9;$i++) "0$i:00" then @for($i=10;$i<=24;$i++) "$i:00").
+const CUSTOM_PRODUCTIVITY_TIMES = Array.from({ length: 24 }, (_, i) => {
+  const hour = i + 1
+  const value = `${String(hour).padStart(2, "0")}:00`
+  return { label: value, value }
+})
 
 const getProductivityCategories = (t) => [
   { label: t("prodReport.neutral"), value: "0" },
@@ -76,18 +77,40 @@ const EmpMonitoringControl = () => {
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
   const currentPage = Math.min(page, totalPages)
 
+  const reportSaveResult = useCallback((res) => {
+    if (res?.success) {
+      Swal.fire({
+        icon: "success",
+        title: "Settings saved",
+        toast: true,
+        position: "top-end",
+        timer: 2000,
+        showConfirmButton: false,
+      })
+    } else {
+      Swal.fire({
+        icon: "error",
+        title: "Failed to save",
+        text: res?.message || "Please try again.",
+        confirmButtonColor: "#ef4444",
+      })
+    }
+  }, [])
+
   const handleProductivityTimeChange = useCallback(
-    (val) => {
-      updateProductivitySettings(val, productivityCategory)
+    async (val) => {
+      const res = await updateProductivitySettings(val, productivityCategory)
+      reportSaveResult(res)
     },
-    [productivityCategory]
+    [productivityCategory, updateProductivitySettings, reportSaveResult]
   )
 
   const handleProductivityCategoryChange = useCallback(
-    (val) => {
-      updateProductivitySettings(productivityTime, val)
+    async (val) => {
+      const res = await updateProductivitySettings(productivityTime, val)
+      reportSaveResult(res)
     },
-    [productivityTime]
+    [productivityTime, updateProductivitySettings, reportSaveResult]
   )
 
   const parseRules = (group) => {

--- a/Frontend/src/components/common/monitoring-control/dialog/MonitoringControlDialog.jsx
+++ b/Frontend/src/components/common/monitoring-control/dialog/MonitoringControlDialog.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react"
 import { useTranslation } from "react-i18next";
 import { Settings, ChevronDown, ChevronRight } from "lucide-react"
+import Swal from "sweetalert2"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -92,55 +93,13 @@ const TRACKING_MODES = [
     { value: "geoLocation", label: "Geo-Location" },
 ]
 
-const SCREENSHOT_FREQUENCIES = [
-    { value: "1", label: "1 per hour" },
-    { value: "2", label: "2 per hour" },
-    { value: "3", label: "3 per hour" },
-    { value: "4", label: "4 per hour" },
-    { value: "6", label: "6 per hour" },
-    { value: "10", label: "10 per hour" },
-    { value: "12", label: "12 per hour" },
-    { value: "20", label: "20 per hour" },
-    { value: "30", label: "30 per hour" },
-]
-
-const IDLE_TIMES = [
-    { value: "1", label: "1 min" },
-    { value: "2", label: "2 min" },
-    { value: "3", label: "3 min" },
-    { value: "5", label: "5 min" },
-    { value: "10", label: "10 min" },
-    { value: "15", label: "15 min" },
-    { value: "20", label: "20 min" },
-    { value: "30", label: "30 min" },
-]
-
+// SCREENSHOT_FREQUENCIES and IDLE_TIMES come from the /settings/options API
+// (mirrors PHP @foreach($options['data']['data']['screenshotFrequency'] as $opt)).
+// VIDEO_QUALITY stays hardcoded — PHP also hardcodes it in monitoringControls.blade.php.
 const VIDEO_QUALITY_OPTIONS = [
     { value: "1", label: "High Quality" },
     { value: "2", label: "Low Quality" },
     { value: "3", label: "Ultra Low" },
-]
-
-const BILLING_BASED_ON = [
-    { value: "", label: "Select" },
-    { value: "office_hours", label: "Office Hours" },
-    { value: "active_hours", label: "Active Hours" },
-    { value: "total_hours", label: "Total Hours" },
-    { value: "productive_hours", label: "Productive Hours" },
-]
-
-const CURRENCY_OPTIONS = [
-    { value: "", label: "Select Currency" },
-    { value: "INR", label: "INR ₹" },
-    { value: "USD", label: "USD $" },
-    { value: "EUR", label: "Euros €" },
-]
-
-const INVOICE_DURATIONS = [
-    { value: "", label: "Select Duration" },
-    { value: "weekly", label: "Weekly" },
-    { value: "biweekly", label: "Biweekly" },
-    { value: "monthly", label: "Monthly" },
 ]
 
 // ─── Main Dialog Component ───────────────────────────────────────────────────
@@ -152,7 +111,16 @@ const MonitoringControlDialog = ({ open, onOpenChange }) => {
         settingsGroupRules,
         updateMonitoringControlAction,
         saving,
+        settingsOptions,
     } = useMonitoringControlStore()
+
+    // Fall back to a minimal hardcoded list only if API data hasn't loaded yet.
+    const SCREENSHOT_FREQUENCIES = settingsOptions?.screenshotFrequency?.length
+        ? settingsOptions.screenshotFrequency
+        : [{ value: "2", label: "2 per hour" }]
+    const IDLE_TIMES = settingsOptions?.idleTime?.length
+        ? settingsOptions.idleTime
+        : [{ value: "5", label: "5 min" }]
 
     const [rules, setRules] = useState(null)
     const [activeTrackingTab, setActiveTrackingTab] = useState("unlimited")
@@ -290,15 +258,6 @@ const MonitoringControlDialog = ({ open, onOpenChange }) => {
             }
         }
 
-        // Work hour billing
-        trackData.work_hour_billing = {
-            is_enabled: updatedRules.work_hour_billing?.is_enabled === "1" ? 1 : 0,
-            currency: updatedRules.work_hour_billing?.currency || "",
-            hours_per_day: parseInt(updatedRules.work_hour_billing?.hours_per_day, 10) || 0,
-            billing_based_on: updatedRules.work_hour_billing?.billing_based_on || "",
-            invoice_duration: updatedRules.work_hour_billing?.invoice_duration || "",
-        }
-
         // Network-based tracking (PHP reformats these)
         if (activeTrackingTab === "networkBased" && networkData.length > 0) {
             trackData.tracking = {
@@ -317,7 +276,16 @@ const MonitoringControlDialog = ({ open, onOpenChange }) => {
         }
 
         const res = await updateMonitoringControlAction(payload)
-        if (!res.success) {
+        if (res.success) {
+            Swal.fire({
+                icon: "success",
+                title: "Settings saved",
+                toast: true,
+                position: "top-end",
+                timer: 2000,
+                showConfirmButton: false,
+            })
+        } else {
             if (res.code === 205) {
                 setErrors({ general: "Please select at least one day for Fixed tracking" })
             } else if (res.code === 207) {
@@ -825,72 +793,6 @@ const MonitoringControlDialog = ({ open, onOpenChange }) => {
                                     </div>
                                 )}
                             </div>
-                        </div>
-                    </AccordionSection>
-
-                    {/* 6. Work Hours Billing */}
-                    <AccordionSection title={t("monitoring.workHoursBilling")}>
-                        <div className="space-y-4">
-                            <div className="flex items-center justify-between py-2">
-                                <span className="text-sm text-slate-700">{t("monitoring.enableWorkHoursBilling")}</span>
-                                <label className="flex items-center gap-2 cursor-pointer">
-                                    <input
-                                        type="checkbox"
-                                        checked={
-                                            String(rules.work_hour_billing?.is_enabled) === "1"
-                                        }
-                                        onChange={(e) =>
-                                            updateRule("work_hour_billing.is_enabled", e.target.checked ? "1" : "0")
-                                        }
-                                        className="w-4 h-4 accent-blue-500"
-                                    />
-                                </label>
-                            </div>
-
-                            {String(rules.work_hour_billing?.is_enabled) === "1" && (
-                                <div className="grid grid-cols-2 gap-4">
-                                    <div>
-                                        <label className="text-xs font-medium text-slate-600 mb-1 block">{t("monitoring.billingBasedOn")}</label>
-                                        <CustomSelect
-                                            placeholder="Select"
-                                            items={BILLING_BASED_ON}
-                                            selected={rules.work_hour_billing?.billing_based_on || ""}
-                                            onChange={(v) => updateRule("work_hour_billing.billing_based_on", v)}
-                                            width="full"
-                                        />
-                                    </div>
-                                    <div>
-                                        <label className="text-xs font-medium text-slate-600 mb-1 block">{t("monitoring.amountPerHour")}</label>
-                                        <Input
-                                            type="number"
-                                            placeholder="Enter amount"
-                                            value={rules.work_hour_billing?.hours_per_day || ""}
-                                            onChange={(e) => updateRule("work_hour_billing.hours_per_day", e.target.value)}
-                                            className="h-9 text-sm"
-                                        />
-                                    </div>
-                                    <div>
-                                        <label className="text-xs font-medium text-slate-600 mb-1 block">{t("monitoring.currency")}</label>
-                                        <CustomSelect
-                                            placeholder="Select Currency"
-                                            items={CURRENCY_OPTIONS}
-                                            selected={rules.work_hour_billing?.currency || ""}
-                                            onChange={(v) => updateRule("work_hour_billing.currency", v)}
-                                            width="full"
-                                        />
-                                    </div>
-                                    <div>
-                                        <label className="text-xs font-medium text-slate-600 mb-1 block">{t("monitoring.invoiceDuration")}</label>
-                                        <CustomSelect
-                                            placeholder="Select Duration"
-                                            items={INVOICE_DURATIONS}
-                                            selected={rules.work_hour_billing?.invoice_duration || ""}
-                                            onChange={(v) => updateRule("work_hour_billing.invoice_duration", v)}
-                                            width="full"
-                                        />
-                                    </div>
-                                </div>
-                            )}
                         </div>
                     </AccordionSection>
 

--- a/Frontend/src/components/common/roles-permission/EmpRolesPermisssion.jsx
+++ b/Frontend/src/components/common/roles-permission/EmpRolesPermisssion.jsx
@@ -16,7 +16,6 @@ import {
     Loader2,
 } from "lucide-react";
 import PaginationComponent from "@/components/common/Pagination";
-import CustomSelect from "@/components/common/elements/CustomSelect";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -30,13 +29,6 @@ import DeleteRoleDialog from "@/components/common/roles-permission/dialog/Delete
 import CloneRoleDialog from "@/components/common/roles-permission/dialog/CloneRoleDialog";
 import ViewRoleDialog from "@/components/common/roles-permission/dialog/ViewRoleDialog";
 import PermissionSettingsDialog from "@/components/common/roles-permission/dialog/PermissionSettingsDialog";
-
-// ─── Constants ──────────────────────────────────────────────────────────────
-
-const MODULE_OPTIONS = [
-    { label: "EMP Monitor", value: "1" },
-    { label: "HRMS", value: "2" },
-];
 
 // ─── Debounce Hook ──────────────────────────────────────────────────────────
 
@@ -237,11 +229,7 @@ const EmpRolesPermission = () => {
     const changePage = useRolesPermissionStore((s) => s.changePage);
     const changePageSize = useRolesPermissionStore((s) => s.changePageSize);
 
-    const selectedModule = useRolesPermissionStore((s) => s.selectedModule);
-    const setSelectedModule = useRolesPermissionStore((s) => s.setSelectedModule);
-
     const toggleRWDPermission = useRolesPermissionStore((s) => s.toggleRWDPermission);
-    const toggleHRMS = useRolesPermissionStore((s) => s.toggleHRMS);
 
     // Dialogs
     const addRoleDialogOpen = useRolesPermissionStore((s) => s.addRoleDialogOpen);
@@ -276,14 +264,12 @@ const EmpRolesPermission = () => {
         }
     }, [successMsg]);
 
-    const isHRMS = selectedModule === "2";
-
     const serverTotalPages = Math.max(1, Math.ceil(totalCount / pagination.pageSize));
     const debouncedSearch = useDebounce((val) => setSearch(val), 300);
 
     const showingFrom = roles.length > 0 ? (pagination.page - 1) * pagination.pageSize + 1 : 0;
     const showingTo = Math.min(pagination.page * pagination.pageSize, totalCount);
-    const colSpanCount = isHRMS ? 8 : 7;
+    const colSpanCount = 7;
 
     return (
         <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-9 w-full">
@@ -319,12 +305,6 @@ const EmpRolesPermission = () => {
                 </div>
 
                 <div className="flex items-center gap-3">
-                    <CustomSelect
-                        placeholder="EMP Monitor"
-                        items={MODULE_OPTIONS}
-                        selected={selectedModule}
-                        onChange={setSelectedModule}
-                    />
                     <ExportDropdown />
                     <Button
                         size="sm"
@@ -375,9 +355,6 @@ const EmpRolesPermission = () => {
                                     <th className="px-4 py-3 text-xs font-semibold text-slate-700 text-left">{t("location")}</th>
                                     <th className="px-4 py-3 text-xs font-semibold text-slate-700 text-left">{t("department")}</th>
                                     <th className="px-4 py-3 text-xs font-semibold text-white text-center bg-[#5C6BC0] min-w-[180px]">{t("action")}</th>
-                                    {isHRMS && (
-                                        <th className="px-4 py-3 text-xs font-semibold text-slate-700 text-center">{t("roles.enableHRMS")}</th>
-                                    )}
                                 </tr>
                             </thead>
                             <tbody className="bg-white">
@@ -436,18 +413,6 @@ const EmpRolesPermission = () => {
                                             <td className="px-4 py-4 bg-slate-50/50 text-center">
                                                 <ActionButtons role={role} />
                                             </td>
-
-                                            {isHRMS && (
-                                                <td className="px-4 py-4 text-center">
-                                                    <div className="flex justify-center">
-                                                        <Checkbox
-                                                            checked={role.permission?.hrms_permission === true || role.permission?.hrms_permission === "1"}
-                                                            onCheckedChange={(checked) => toggleHRMS(role.id, checked)}
-                                                            className="border-slate-300 data-[state=checked]:bg-blue-500 data-[state=checked]:border-blue-500"
-                                                        />
-                                                    </div>
-                                                </td>
-                                            )}
                                         </tr>
                                     ))
                                 )}

--- a/Frontend/src/components/common/roles-permission/dialog/PermissionSettingsDialog.jsx
+++ b/Frontend/src/components/common/roles-permission/dialog/PermissionSettingsDialog.jsx
@@ -16,7 +16,6 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
     const permissionRoleData = useRolesPermissionStore((s) => s.permissionRoleData);
     const categorizedPermissions = useRolesPermissionStore((s) => s.categorizedPermissions);
     const saveFeaturePermissions = useRolesPermissionStore((s) => s.saveFeaturePermissions);
-    const selectedModule = useRolesPermissionStore((s) => s.selectedModule);
 
     const [checkedIds, setCheckedIds] = useState(new Set());
     const [expandedCategories, setExpandedCategories] = useState(new Set());
@@ -39,24 +38,35 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
 
     const rolePermission = permissionRoleData?.permission || {};
 
-    const filteredCategories = useMemo(() => {
-        const filtered = {};
+    // Mirrors PHP roleCommonScript.permissionSetting() filter for EMP module only.
+    // For the "Employee" role, PHP only surfaces the "My Productivity" card.
+    // Category headers render whenever the category has any source perms — even
+    // if every checkbox inside is filtered out by the role's RWD — so the user
+    // still sees what's available and understands why it's empty.
+    const visibleCategories = useMemo(() => {
+        const result = {};
         Object.entries(categorizedPermissions).forEach(([category, perms]) => {
-            if (permissionRoleData?.name === "Employee" && selectedModule !== "2" && category !== "My Productivity") {
+            const categoryKeyNoSpace = category.replace(/\s+/g, "");
+            if (permissionRoleData?.name === "Employee" && categoryKeyNoSpace !== "MyProductivity") {
                 return;
             }
+            if (!perms?.length) return;
+
             const allowedPerms = perms.filter((p) => {
-                if (p.status === 1 && (rolePermission.read === true || rolePermission.read === undefined)) return true;
+                if (p.status === 1 && rolePermission.read === true) return true;
                 if (p.status === 2 && rolePermission.write === true) return true;
                 if (p.status === 3 && rolePermission.delete === true) return true;
                 return false;
             });
-            if (allowedPerms.length > 0) {
-                filtered[category] = allowedPerms;
-            }
+            result[category] = allowedPerms;
         });
-        return filtered;
-    }, [categorizedPermissions, rolePermission, permissionRoleData, selectedModule]);
+        return result;
+    }, [categorizedPermissions, rolePermission, permissionRoleData]);
+
+    const hasAnyVisibleCheckbox = useMemo(
+        () => Object.values(visibleCategories).some((arr) => arr.length > 0),
+        [visibleCategories]
+    );
 
     const toggleCategory = (category) => {
         setExpandedCategories((prev) => {
@@ -76,8 +86,9 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
                 next.add(permId);
             }
 
+            // PHP checkedChnage: any non-View toggle also forces the View checkbox on.
             if (status === 2 || status === 3) {
-                const viewPerm = filteredCategories[category]?.find((p) => p.status === 1);
+                const viewPerm = visibleCategories[category]?.find((p) => p.status === 1);
                 if (viewPerm) next.add(viewPerm.id);
             }
 
@@ -104,7 +115,6 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
             added,
             removed,
             mailStatus: sendEmail,
-            moduleType: selectedModule,
         });
     };
 
@@ -142,9 +152,8 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
                     )}
 
                     <div className="space-y-1">
-                        {Object.entries(filteredCategories).map(([category, perms]) => {
+                        {Object.entries(visibleCategories).map(([category, perms]) => {
                             const isExpanded = expandedCategories.has(category);
-                            const categoryKey = category.replace(/\s+/g, "");
 
                             return (
                                 <div key={category} className="border border-slate-100 rounded-lg overflow-hidden">
@@ -160,7 +169,11 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
                                     </button>
                                     {isExpanded && (
                                         <div className="px-4 py-3 flex flex-wrap gap-4">
-                                            {perms.map((perm) => {
+                                            {perms.length === 0 ? (
+                                                <p className="text-xs text-slate-400 italic">
+                                                    Enable Read / Write / Delete on this role to access these permissions.
+                                                </p>
+                                            ) : perms.map((perm) => {
                                                 const isChecked = checkedIds.has(perm.id);
                                                 const isViewLocked = perm.status === 1 && perms.some(
                                                     (p) => p.status !== 1 && checkedIds.has(p.id)
@@ -187,10 +200,20 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
                             );
                         })}
 
-                        {Object.keys(filteredCategories).length === 0 && (
+                        {Object.keys(visibleCategories).length === 0 && (
                             <div className="text-center py-8">
                                 <p className="text-sm text-slate-400">
-                                    No permissions available. Enable Read/Write/Delete on the role first.
+                                    {Object.keys(categorizedPermissions).length === 0
+                                        ? "Loading permissions…"
+                                        : "No permissions defined for this role."}
+                                </p>
+                            </div>
+                        )}
+
+                        {Object.keys(visibleCategories).length > 0 && !hasAnyVisibleCheckbox && (
+                            <div className="text-center py-3">
+                                <p className="text-xs text-slate-400 italic">
+                                    Tip: enable Read / Write / Delete on the role (in the table) to populate these categories.
                                 </p>
                             </div>
                         )}

--- a/Frontend/src/page/protected/admin/monitoring-control/monitoringControlStore.js
+++ b/Frontend/src/page/protected/admin/monitoring-control/monitoringControlStore.js
@@ -57,15 +57,8 @@ const DEFAULT_RULES = {
         geoLocation: [],
         projectBased: [],
     },
-    work_hour_billing: {
-        is_enabled: "0",
-        billing_based_on: "",
-        hours_per_day: "",
-        currency: "",
-        invoice_duration: "",
-    },
-    productiveHours: { hour: "08:00" },
-    productivityCategory: "0",
+    productiveHours: { hour: "08:00", mode: "fixed" },
+    productivityCategory: 0,
 };
 
 const useMonitoringControlStore = create((set, get) => ({
@@ -120,31 +113,49 @@ const useMonitoringControlStore = create((set, get) => ({
     loadInitialData: async () => {
         try {
             set({ loading: true });
-            const [groupsRes, rolesRes, optionsRes] = await Promise.all([
+            // Fetch in parallel: groups list, roles for the create-group dropdown,
+            // settings options, and—critically—the organisation default rules so
+            // updates don't overwrite the saved settings with a stale constant.
+            const [groupsRes, rolesRes, optionsRes, orgFeatureRes] = await Promise.all([
                 getGroups({ limit: 10, skip: 0 }),
                 getRoles(),
                 getSettingsOptions(),
+                getMonitoringSettings(),
             ]);
+
+            // Backend response shape: { code, data: { ption, data: { screenshotFrequency, idleTime, ... } } }
+            // Map each {id, name, value} to {value, label} for CustomSelect.
+            const opts = optionsRes?.data?.data ?? null;
+            const mapOpts = (arr) =>
+                Array.isArray(arr) ? arr.map((o) => ({ value: String(o.value), label: o.name })) : [];
 
             const updates = {
                 roles: rolesRes || [],
-                settingsOptions: optionsRes,
+                settingsOptions: opts
+                    ? {
+                          screenshotFrequency: mapOpts(opts.screenshotFrequency),
+                          idleTime: mapOpts(opts.idleTime),
+                          breakTime: mapOpts(opts.beakTime), // backend typo: "beakTime"
+                          mobileGeoLocationFrequency: mapOpts(opts.mobileGeoLocationFrequency),
+                      }
+                    : null,
                 loading: false,
             };
 
             if (groupsRes?.code === 200) {
                 updates.groups = groupsRes.data || [];
                 updates.totalCount = (groupsRes.count || 0) + 1; // +1 for default row
-                if (groupsRes.data?.[0]?.rules) {
-                    try {
-                        const rules = typeof groupsRes.data[0].rules === "string"
-                            ? JSON.parse(groupsRes.data[0].rules)
-                            : groupsRes.data[0].rules;
-                        updates.defaultRules = { ...DEFAULT_RULES, ...rules };
-                        updates.productivityTime = rules?.productiveHours?.hour || "08:00";
-                        updates.productivityCategory = String(rules?.productivityCategory || "0");
-                    } catch { /* use defaults */ }
-                }
+            }
+
+            // Org default settings live behind /organization/admin-feature
+            // (NOT in the groups list — groups are user-created subsets).
+            // Backend wraps it as: { code, message, data: { data: { feature }, ack } }
+            // so we must drill in two .data hops to reach `feature`.
+            const feature = orgFeatureRes?.data?.data?.feature ?? null;
+            if (feature) {
+                updates.defaultRules = { ...DEFAULT_RULES, ...feature };
+                updates.productivityTime = feature?.productiveHours?.hour || "08:00";
+                updates.productivityCategory = String(feature?.productivityCategory ?? "0");
             }
 
             set(updates);
@@ -267,7 +278,22 @@ const useMonitoringControlStore = create((set, get) => ({
             const res = await updateMonitoringControl(payload);
             set({ saving: false });
             if (res?.code === 200) {
+                // Refresh the groups table.
                 get().fetchGroups();
+                // For the org default (group_id=0), also refetch the org feature
+                // so defaultRules isn't stale when the dialog reopens. Otherwise
+                // the dialog would render the old values until a page reload.
+                if (payload?.group_id == 0 || payload?.group_id === "0") {
+                    const fresh = await getMonitoringSettings();
+                    const feature = fresh?.data?.data?.feature ?? null;
+                    if (feature) {
+                        set({
+                            defaultRules: { ...get().defaultRules, ...feature },
+                            productivityTime: feature?.productiveHours?.hour || get().productivityTime,
+                            productivityCategory: String(feature?.productivityCategory ?? get().productivityCategory),
+                        });
+                    }
+                }
                 set({ monitoringDialogOpen: false, settingsGroupId: null, settingsGroupRules: null });
                 return { success: true, message: res.msg };
             }
@@ -281,22 +307,35 @@ const useMonitoringControlStore = create((set, get) => ({
     updateProductivitySettings: async (time, category) => {
         try {
             const { defaultRules } = get();
+            // Send the FULL current rules object plus the two changed fields.
+            // The backend overwrites org rules with whatever's in track_data
+            // (it doesn't merge), so any missing field would be lost.
+            // productivityCategory must be a number (Joi schema: valid(0,1,2)).
             const payload = {
                 track_data: {
                     ...defaultRules,
                     productiveHours: { mode: "fixed", hour: time },
-                    productivityCategory: category,
+                    productivityCategory: Number(category),
                 },
                 group_id: 0,
             };
             const res = await updateMonitoringControl(payload);
             if (res?.code === 200) {
-                set({ productivityTime: time, productivityCategory: category });
+                set((state) => ({
+                    productivityTime: time,
+                    productivityCategory: String(category),
+                    defaultRules: {
+                        ...state.defaultRules,
+                        productiveHours: { mode: "fixed", hour: time },
+                        productivityCategory: Number(category),
+                    },
+                }));
                 return { success: true };
             }
-            return { success: false, message: res?.msg };
+            return { success: false, message: res?.error || res?.msg || res?.message };
         } catch (error) {
-            return { success: false, message: "Failed to update productivity settings" };
+            console.error("updateProductivitySettings error", error);
+            return { success: false, message: error?.response?.data?.error || "Failed to update productivity settings" };
         }
     },
 

--- a/Frontend/src/page/protected/admin/roles-permissions/rolesPermissionStore.js
+++ b/Frontend/src/page/protected/admin/roles-permissions/rolesPermissionStore.js
@@ -12,7 +12,6 @@ import {
     getLocationsWithDept,
     getDepartmentsByLocation,
     categorizePermissions,
-    updateHRMSPermission,
     exportToExcel,
     exportToCSV,
     exportToPDF,
@@ -36,9 +35,6 @@ export const useRolesPermissionStore = create((set, get) => ({
     // ── Pagination ──────────────────────────────────────────────────────────
     pagination: { page: 1, pageSize: 10 },
     search: "",
-
-    // ── Module Selection ────────────────────────────────────────────────────
-    selectedModule: "1",
 
     // ── Dialog State ────────────────────────────────────────────────────────
     addRoleDialogOpen: false,
@@ -67,8 +63,6 @@ export const useRolesPermissionStore = create((set, get) => ({
     setPagination: (key, value) => {
         set((state) => ({ pagination: { ...state.pagination, [key]: value } }));
     },
-
-    setSelectedModule: (module) => set({ selectedModule: module }),
 
     clearError: () => set({ error: null }),
     clearSuccess: () => set({ successMsg: null }),
@@ -337,36 +331,6 @@ export const useRolesPermissionStore = create((set, get) => ({
             console.error("Save feature permissions error:", error);
             set({ saving: false, error: "Failed to update permissions" });
             return { success: false };
-        }
-    },
-
-    toggleHRMS: async (roleId, currentChecked) => {
-        const newStatus = currentChecked ? 1 : 2;
-
-        set((state) => ({
-            roles: state.roles.map((r) =>
-                r.id === roleId
-                    ? { ...r, permission: { ...r.permission, hrms_permission: currentChecked } }
-                    : r
-            ),
-        }));
-
-        const result = await updateHRMSPermission({
-            roleId,
-            status: newStatus,
-        });
-
-        if (result.success) {
-            set({ successMsg: result.message });
-        } else {
-            set((state) => ({
-                roles: state.roles.map((r) =>
-                    r.id === roleId
-                        ? { ...r, permission: { ...r.permission, hrms_permission: !currentChecked } }
-                        : r
-                ),
-                error: result.message,
-            }));
         }
     },
 

--- a/Frontend/src/page/protected/admin/roles-permissions/service.js
+++ b/Frontend/src/page/protected/admin/roles-permissions/service.js
@@ -196,14 +196,15 @@ export const updateRolePermission = async ({ roleId, name, added, removed, type 
 };
 
 // ─── API: Update Feature Permissions (permission settings modal) ────────────
+// EMP module only (type=1). HRMS was removed from the UI.
 
-export const updateFeaturePermissions = async ({ roleId, name, permissionIds, added, removed, mailStatus, moduleType = "1" }) => {
+export const updateFeaturePermissions = async ({ roleId, name, permissionIds, added, removed, mailStatus }) => {
     try {
         const payload = {
             role_id: parseInt(roleId, 10),
             name,
             permission_ids: permissionIds,
-            type: moduleType,
+            type: "1",
             permission: { send_mail: mailStatus },
         };
 
@@ -239,25 +240,6 @@ export const deleteRole = async (roleId) => {
     } catch (error) {
         console.error("Roles: Delete role error:", error);
         return { success: false, message: error.response?.data?.message || "Failed to delete role" };
-    }
-};
-
-// ─── API: Update HRMS Permission Toggle ─────────────────────────────────────
-
-export const updateHRMSPermission = async ({ roleId, permissionId = 203, status }) => {
-    try {
-        const { data } = await apiService.apiInstance.post("/settings/add-HRMS-Role", {
-            role_id: roleId,
-            permission_id: permissionId,
-            status,
-        });
-        if (data?.statusCode === 200 || data?.code === 200) {
-            return { success: true, message: data?.data?.message || data?.message || "HRMS permission updated" };
-        }
-        return { success: false, message: data?.data?.message || data?.message || "Failed to update HRMS permission" };
-    } catch (error) {
-        console.error("Roles: Update HRMS permission error:", error);
-        return { success: false, message: "Failed to update HRMS permission" };
     }
 };
 
@@ -385,6 +367,22 @@ const PERMISSION_MAP = {
     me_web_usage_view: { category: "My Productivity", name: "Web Usage" },
     me_keystrokes_view: { category: "My Productivity", name: "Keystrokes" },
     me_screenshots_view: { category: "My Productivity", name: "Screenshots" },
+    me_screen_record_view: { category: "My Productivity", name: "Screen Recording" },
+    locate_me_employe_read: { category: "My Productivity", name: "Locate Me" },
+    project_tasks_view: { category: "Project Tasks", name: "View" },
+    project_tasks_create: { category: "Project Tasks", name: "Create" },
+    project_tasks_modify: { category: "Project Tasks", name: "Modify" },
+    project_tasks_delete: { category: "Project Tasks", name: "Delete" },
+    project_tasks_download: { category: "Project Tasks", name: "Download" },
+    screen_record_view: { category: "Employee Screen Video Recorder", name: "View" },
+    non_admin_screen_casting: { category: "Screen Casting", name: "View" },
+    email_monitoring_view: { category: "Email Monitoring", name: "View" },
+    email_monitoring_download: { category: "Email Monitoring", name: "Download" },
+    report_system_logs_view: { category: "System Activity Logs", name: "View" },
+    report_system_logs_download: { category: "System Activity Logs", name: "Download" },
+    reseller_view_details: { category: "Reseller Access Settings", name: "View" },
+    reseller_edit_details: { category: "Reseller Access Settings", name: "Modify" },
+    reseller_delete_details: { category: "Reseller Access Settings", name: "Delete" },
     roles_browse: { category: "Roles", name: "View" },
     roles_create: { category: "Roles", name: "Create" },
     roles_modify: { category: "Roles", name: "Modify" },


### PR DESCRIPTION
## Summary

### Roles & Permissions
- **PermissionSettingsDialog**: category cards now always render when the category has source permissions (matches PHP `roleCommonScript.permissionSetting` behaviour). Previously the card was dropped when RWD was off, leaving a misleading blank state.
- Empty-state messaging differentiates *loading*, *no permissions defined*, and *enable Read/Write/Delete to populate* instead of a single generic line.
- **HRMS removed entirely** — dropped the EMP/HRMS module dropdown, the `Enable HRMS` column/toggle, `selectedModule`/`toggleHRMS`, `updateHRMSPermission`, and the `/settings/add-HRMS-Role` call. `updateFeaturePermissions` sends `type="1"` (EMP) unconditionally.
- Added 13 missing entries to `PERMISSION_MAP` that PHP had but React silently dropped: Project Tasks (5), My Productivity extras (Screen Recording, Locate Me), Employee Screen Video Recorder, Screen Casting, Email Monitoring (2), System Activity Logs (2), Reseller Access Settings (3).

### Monitoring Control — Productivity Time dropdown
- Replaced hardcoded 5-value list (`06:00`–`10:00`) with the full `01:00`–`24:00` range matching PHP `@for($i=1..24)` in `groups.blade.php`.

### Monitoring Control — Productivity Category dropdown (was silently reverting)
- **Root cause**: `loadInitialData` pulled "defaults" from `groups[0].rules` (a custom group) instead of org defaults at `/organization/admin-feature`. The backend overwrites org rules with whatever `track_data` is sent (no merge), so saves used stale baselines that validation rejected.
- Now calls `getMonitoringSettings()` and reads `feature` from `data.data.feature` (backend double-wraps).
- Coerces `productivityCategory` to `Number` (Joi schema: `valid(0,1,2)`).
- Refreshes `defaultRules` from the server after a successful save so the dialog isn't stale on reopen.
- Swal toast surfaces the backend error message on failure. Success toast uses literal text instead of the untranslated `common.saved` key.

### Monitoring Control — Screenshot Frequency / Idle Time dropdowns
- Were hardcoded with invalid values (10 & 20 per hour don't exist on the backend; 1/2/3/30 min for idle time don't exist either).
- Dialog now reads from `settingsOptions.screenshotFrequency` / `.idleTime` which are mapped from the `/settings/options` API response in the store. Org-specific high-frequency options (120/180/240/etc. per hour) appear automatically without further frontend changes.
- `VIDEO_QUALITY` stays hardcoded — PHP also hardcodes it.

### Monitoring Control — Dialog save success feedback
- `updateMonitoringControlAction` refetches `/organization/admin-feature` after saving the default (`group_id=0`) so the dialog reopens with the saved values (previously it kept showing the old values until a page reload).
- Dialog's `handleSave` fires a Swal success toast on success.

### Work Hour Billing removed (out of scope for EmpMonitor)
- Dropped the `work_hour_billing` block from `DEFAULT_RULES`.
- Removed `BILLING_BASED_ON` / `CURRENCY_OPTIONS` / `INVOICE_DURATIONS` constants and the Work Hours Billing accordion from the dialog.
- Removed the `work_hour_billing` assignment from `handleSave`'s `trackData`.

## Test plan
- [ ] Admin → Settings → Roles & Permissions → gear icon on any role: dialog shows appropriate category cards based on the role's RWD settings (and a helpful hint when all checkboxes filter out).
- [ ] Roles & Permissions page: no EMP/HRMS dropdown visible, no `Enable HRMS` column in the table.
- [ ] Settings → Monitoring Control → Custom Productivity Time dropdown: all 24 hourly options (`01:00`–`24:00`) appear.
- [ ] Productivity Category dropdown: changing value shows "Settings saved" toast; hard-refresh the page — selection persists.
- [ ] Monitoring Settings dialog → Screenshot Frequency: shows values from `/settings/options` (1/2/3/4/6/12/30/60 per hour + any org-specific extras), not the old invalid list.
- [ ] Monitoring Settings dialog → Idle Time: shows 5/10/15/20 min (not the old 1/2/3/30).
- [ ] Monitoring Settings dialog → Save: success toast appears; close and reopen dialog — saved values are reflected.
- [ ] No "Work Hours Billing" section visible anywhere in Monitoring Control.