### PR TITLE
Fix Permission Settings dialog and storage data id type

### DIFF
--- a/Frontend/src/components/common/roles-permission/dialog/PermissionSettingsDialog.jsx
+++ b/Frontend/src/components/common/roles-permission/dialog/PermissionSettingsDialog.jsx
@@ -43,7 +43,19 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
     // Category headers render whenever the category has any source perms — even
     // if every checkbox inside is filtered out by the role's RWD — so the user
     // still sees what's available and understands why it's empty.
+    //
+    // PHP precedence quirk we must preserve:
+    //   if (status === 1 && read === true || read === undefined) allowed = 1
+    // reads as  (status===1 && read===true) || read===undefined  — meaning when
+    // the role's permission object has no read/write/delete keys at all (only
+    // send_mail, etc.), every permission is allowed. Default roles frequently
+    // hit this path, so treating missing RWD keys as "deny" would leave the
+    // dialog looking empty even though the role is logically unrestricted.
     const visibleCategories = useMemo(() => {
+        const readDef = rolePermission.read !== undefined;
+        const writeDef = rolePermission.write !== undefined;
+        const deleteDef = rolePermission.delete !== undefined;
+
         const result = {};
         Object.entries(categorizedPermissions).forEach(([category, perms]) => {
             const categoryKeyNoSpace = category.replace(/\s+/g, "");
@@ -53,9 +65,10 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
             if (!perms?.length) return;
 
             const allowedPerms = perms.filter((p) => {
-                if (p.status === 1 && rolePermission.read === true) return true;
-                if (p.status === 2 && rolePermission.write === true) return true;
-                if (p.status === 3 && rolePermission.delete === true) return true;
+                // Missing RWD key → PHP allows regardless of status.
+                if (p.status === 1 && (!readDef || rolePermission.read === true)) return true;
+                if (p.status === 2 && (!writeDef || rolePermission.write === true)) return true;
+                if (p.status === 3 && (!deleteDef || rolePermission.delete === true)) return true;
                 return false;
             });
             result[category] = allowedPerms;

--- a/Frontend/src/page/protected/admin/storage-types/service.js
+++ b/Frontend/src/page/protected/admin/storage-types/service.js
@@ -204,7 +204,13 @@ export const addWebdavIntegration = async (payload) => {
 
 export const updateStorageData = async (payload) => {
   try {
-    const { data } = await apiService.apiInstance.put("/storage/update-storage-data", payload);
+    // Backend Joi validator requires storage_data_id / storage_type_id as Numbers.
+    const normalized = {
+      ...payload,
+      ...(payload.storage_data_id !== undefined && { storage_data_id: Number(payload.storage_data_id) }),
+      ...(payload.storage_type_id !== undefined && { storage_type_id: Number(payload.storage_type_id) }),
+    };
+    const { data } = await apiService.apiInstance.put("/storage/update-storage-data", normalized);
     return ok(data);
   } catch (error) {
     console.error("Storage: updateStorageData error", error);
@@ -214,8 +220,12 @@ export const updateStorageData = async (payload) => {
 
 export const deleteStorageData = async (storageDataId) => {
   try {
+    // Backend inconsistency: the delete endpoint's ValidateId uses Joi.string()
+    // (whereas update/updateOption use Joi.number()). Send a string here — a
+    // number gets rejected by the validator and the controller returns a
+    // misleading hardcoded "storage_data_id Must Be Number" message.
     const { data } = await apiService.apiInstance.delete("/storage/delete-storage-data", {
-      data: { storage_data_id: storageDataId },
+      data: { storage_data_id: String(storageDataId) },
     });
     return ok(data);
   } catch (error) {
@@ -227,7 +237,7 @@ export const deleteStorageData = async (storageDataId) => {
 export const updateStorageOption = async (storageDataId) => {
   try {
     const { data } = await apiService.apiInstance.put("/storage/update-storage-option", {
-      storage_data_id: storageDataId,
+      storage_data_id: Number(storageDataId),
       status: "1",
     });
     return ok(data);


### PR DESCRIPTION
Follow-ups to #78. Two unrelated bug fixes found while testing the merged changes.

## Summary

### PermissionSettingsDialog — empty for default roles
Default roles (e.g. `Employee`) often have a permission JSON shaped like `{send_mail: 1}` with no `read`/`write`/`delete` keys at all. After #78 the filter required `permission.read === true` explicitly, so default roles whose RWD keys were missing showed an empty dialog ("Enable Read/Write/Delete...") even though PHP renders them as fully populated.

Restored the PHP-precedence fallback:
```js
// PHP: if (status === 1 && read === true || read === undefined) allowed = 1
// reads as: (status===1 && read===true) || read===undefined
```
React filter now matches: missing RWD key passes that status; defined-and-`false` blocks (same as before).

### Storage `storage_data_id` type mismatch
Deleting / activating storage rows returned `404 "storage_data_id Must Be Number"`.

Root cause: backend validators are inconsistent.
| Endpoint | Validator | Expected type |
|---|---|---|
| `update-storage-data` | `UpdateStorageData` | `Joi.number()` |
| `update-storage-option` | `UpdateStorageOption` | `Joi.number()` |
| `delete-storage-data` | `ValidateId` | `Joi.string()` ⚠️ |

`ValidateId` uses `Joi.string()` instead of `Joi.number()`, but the controller hardcodes the same misleading "Must Be Number" message regardless of the real validation failure ([Storage.controller.js:761](https://github.com/EmpCloud/emp-monitor/blob/main/Backend/admin/src/routes/v3/storage/Storage.controller.js#L761)).

Fix:
- `updateStorageData` / `updateStorageOption` → coerce id to **Number** (matches Joi.number)
- `deleteStorageData` → coerce id to **String** (matches the inconsistent Joi.string in ValidateId)

## Test plan
- [ ] Admin → Settings → Roles & Permissions: open Permission Settings on the Employee role — "My Productivity" card now shows the 6 `me_*` checkboxes (was empty before).
- [ ] Open Permission Settings on a custom role with explicit `read=false` — still shows "Enable Read/Write/Delete..." tip (no regression).
- [ ] Storage page: click delete on any storage row — succeeds with "Deleted" toast (was 404 before).
- [ ] Storage page: activate a Not Active row — succeeds (was 404 with same misleading message).
- [ ] Storage page: edit an existing row — saves successfully.

## Optional backend follow-up
[Storage.validator.js:33](https://github.com/EmpCloud/emp-monitor/blob/main/Backend/admin/src/routes/v3/storage/Storage.validator.js#L33) should be `Joi.number()` (or `Joi.alternatives().try(Joi.number(), Joi.string())`) for consistency with the other storage validators. This frontend fix unblocks users without needing a backend redeploy.