### PR TITLE
Gate employee dashboard tabs by role permissions

### DIFF
--- a/Frontend/src/page/protected/admin/roles-permissions/service.js
+++ b/Frontend/src/page/protected/admin/roles-permissions/service.js
@@ -368,7 +368,6 @@ const PERMISSION_MAP = {
     me_keystrokes_view: { category: "My Productivity", name: "Keystrokes" },
     me_screenshots_view: { category: "My Productivity", name: "Screenshots" },
     me_screen_record_view: { category: "My Productivity", name: "Screen Recording" },
-    locate_me_employe_read: { category: "My Productivity", name: "Locate Me" },
     project_tasks_view: { category: "Project Tasks", name: "View" },
     project_tasks_create: { category: "Project Tasks", name: "Create" },
     project_tasks_modify: { category: "Project Tasks", name: "Modify" },

--- a/Frontend/src/page/protected/employee/dashboard/index.jsx
+++ b/Frontend/src/page/protected/employee/dashboard/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import moment from "moment";
 import {
@@ -6,6 +6,7 @@ import {
   Globe, LayoutGrid, PenTool,
 } from "lucide-react";
 import useEmployeeSession from "../../../../sessions/employeeSession";
+import { usePermission } from "../../../../hooks/usePermission";
 
 import ProfileHeader      from "../../admin/employee-profile/ProfileHeader";
 import ProductivityTab    from "../../admin/employee-profile/ProductivityTab";
@@ -18,14 +19,14 @@ import AppHistoryTab      from "../../admin/employee-profile/AppHistoryTab";
 import KeyStrokesTab      from "../../admin/employee-profile/KeyStrokesTab";
 
 const getTabItems = (t) => [
-  { key: "productivity",    label: t("productivity"),        icon: BarChart3  },
-  { key: "timesheets",      label: t("timesheets"),          icon: Clock      },
-  { key: "screenshots",     label: t("ss"),                  icon: Camera     },
-  { key: "screencast",      label: t("screenCast"),          icon: Monitor    },
-  { key: "screenrecording", label: t("ep_screen_recording"), icon: Video      },
-  { key: "webhistory",      label: t("ep_web_history"),      icon: Globe      },
-  { key: "apphistory",      label: t("ep_app_history"),      icon: LayoutGrid },
-  { key: "keystrokes",      label: t("keystroke"),           icon: PenTool    },
+  { key: "productivity",    label: t("productivity"),        icon: BarChart3,  perm: "me_productivity_view"       },
+  { key: "timesheets",      label: t("timesheets"),          icon: Clock,      perm: "me_timesheet_view"          },
+  { key: "screenshots",     label: t("ss"),                  icon: Camera,     perm: "me_screenshots_view"        },
+  { key: "screencast",      label: t("screenCast"),          icon: Monitor,    perm: "non_admin_screen_casting"   },
+  { key: "screenrecording", label: t("ep_screen_recording"), icon: Video,      perm: "me_screen_record_view"      },
+  { key: "webhistory",      label: t("ep_web_history"),      icon: Globe,      perm: "me_web_usage_view"          },
+  { key: "apphistory",      label: t("ep_app_history"),      icon: LayoutGrid, perm: "me_application_usage_view"  },
+  { key: "keystrokes",      label: t("keystroke"),           icon: PenTool,    perm: "me_keystrokes_view"         },
 ];
 
 const tabComponents = {
@@ -42,12 +43,29 @@ const tabComponents = {
 export default function EmployeeDashboard() {
   const { t } = useTranslation();
   const { employee: session } = useEmployeeSession();
+  const { hasPermission } = usePermission(session);
 
-  const [activeTab, setActiveTab] = useState("productivity");
   const [startDate, setStartDate] = useState(moment().subtract(6, "days").format("YYYY-MM-DD"));
   const [endDate,   setEndDate]   = useState(moment().format("YYYY-MM-DD"));
 
-  const tabs = getTabItems(t);
+  const tabs = useMemo(
+    () => getTabItems(t).filter(({ perm }) => !perm || hasPermission(perm)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [session, t],
+  );
+
+  const [activeTab, setActiveTab] = useState(() => tabs[0]?.key ?? null);
+
+  // If the active tab gets filtered out (e.g. after permission refresh), fall back to the first visible tab.
+  useEffect(() => {
+    if (tabs.length === 0) {
+      if (activeTab !== null) setActiveTab(null);
+      return;
+    }
+    if (!tabs.some((tab) => tab.key === activeTab)) {
+      setActiveTab(tabs[0].key);
+    }
+  }, [tabs, activeTab]);
 
   // Build the employee object all tab components expect
   const employee = {
@@ -55,7 +73,7 @@ export default function EmployeeDashboard() {
     name: session?.full_name ?? session?.user_name ?? t("ep_my_account"),
   };
 
-  const ActiveComponent = tabComponents[activeTab];
+  const ActiveComponent = activeTab ? tabComponents[activeTab] : null;
 
   return (
     <div className="bg-slate-200 w-full min-h-screen">
@@ -71,29 +89,37 @@ export default function EmployeeDashboard() {
           />
 
           {/* Tab navigation */}
-          <div className="grid grid-cols-4 2xl:grid-cols-8 gap-4">
-            {tabs.map(({ key, label, icon: Icon }) => (
-              <button
-                key={key}
-                onClick={() => setActiveTab(key)}
-                className={`flex items-center justify-center gap-1.5 px-4 py-2 rounded-xl text-[13px] font-medium border transition-all duration-200 ${
-                  activeTab === key
-                    ? "bg-violet-600 text-white border-violet-600 shadow-sm"
-                    : "bg-white text-gray-600 border-gray-200 hover:border-gray-300 hover:bg-gray-50"
-                }`}
-              >
-                <Icon size={14} />
-                {label}
-              </button>
-            ))}
-          </div>
+          {tabs.length > 0 && (
+            <div className="grid grid-cols-4 2xl:grid-cols-8 gap-4">
+              {tabs.map(({ key, label, icon: Icon }) => (
+                <button
+                  key={key}
+                  onClick={() => setActiveTab(key)}
+                  className={`flex items-center justify-center gap-1.5 px-4 py-2 rounded-xl text-[13px] font-medium border transition-all duration-200 ${
+                    activeTab === key
+                      ? "bg-violet-600 text-white border-violet-600 shadow-sm"
+                      : "bg-white text-gray-600 border-gray-200 hover:border-gray-300 hover:bg-gray-50"
+                  }`}
+                >
+                  <Icon size={14} />
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
 
           {/* Active tab content */}
-          <ActiveComponent
-            employee={employee}
-            startDate={startDate}
-            endDate={endDate}
-          />
+          {ActiveComponent ? (
+            <ActiveComponent
+              employee={employee}
+              startDate={startDate}
+              endDate={endDate}
+            />
+          ) : (
+            <div className="py-16 text-center text-sm text-gray-500">
+              {t("no_permission_to_view") || "You don't have permission to view any of these sections. Contact your administrator."}
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Employee dashboard tabs (Productivity, Timesheets, Screenshots, Screen Cast, Screen Recording, Web History, App History, Key Strokes) are now filtered by the role's "My Productivity" permissions — matching what admins configure in Roles & Permissions.
- Uses the existing `usePermission` hook against the employee session's `permissionData` (same pattern as the non-admin sidebar). No new API calls.
- Drops the unused `Locate Me` permission from the admin Roles & Permissions modal — there is no corresponding employee tab today.

## Permission → tab mapping
| Admin permission | Employee tab |
| --- | --- |
| `me_productivity_view` | Productivity |
| `me_timesheet_view` | Timesheets |
| `me_screenshots_view` | Screenshots |
| `non_admin_screen_casting` | Screen Cast |
| `me_screen_record_view` | Screen Recording |
| `me_web_usage_view` | Web History |
| `me_application_usage_view` | App History |
| `me_keystrokes_view` | Key Strokes |

If the currently active tab gets filtered out, the dashboard falls back to the first visible tab. If the employee has none of these permissions, an empty-state message is shown instead of any tab content.

## Test plan
- [ ] As admin, open Roles & Permissions → edit the Employee role → confirm "Locate Me" is no longer shown under "My Productivity".
- [ ] Toggle off a subset of permissions (e.g. Screenshots, Web Usage, Keystrokes) → Save.
- [ ] Log in as an employee with that role → confirm only the permitted tabs are visible; denied tabs are hidden entirely.
- [ ] Toggle every "My Productivity" permission off → confirm the tab row is hidden and the empty-state message renders.
- [ ] While viewing a tab, have admin revoke its permission → refresh → confirm the dashboard falls back to the first visible tab (no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)