### PR TITLE
Fix entries dropdown cutting off "100" in page-size selects

### DIFF
--- a/Frontend/src/components/common/elements/ShowEntries.jsx
+++ b/Frontend/src/components/common/elements/ShowEntries.jsx
@@ -15,7 +15,7 @@ export default function ShowEntries({ value, onChange }) {
     <div className="flex items-center gap-2">
       <span className="text-[13px] text-gray-500 font-medium">{t("show")}</span>
       <Select value={String(value)} onValueChange={onChange}>
-        <SelectTrigger className="h-8 w-16 text-[13px] rounded-lg border-gray-200">
+        <SelectTrigger className="h-8 w-20 text-[13px] rounded-lg border-gray-200">
           <SelectValue placeholder="10" />
         </SelectTrigger>
         <SelectContent className="rounded-xl">

--- a/Frontend/src/components/common/elements/ViewReportModal.jsx
+++ b/Frontend/src/components/common/elements/ViewReportModal.jsx
@@ -206,7 +206,7 @@ const ViewReportModal = ({
                   setPage(1);
                 }}
               >
-                <SelectTrigger className="h-8 w-16 text-xs rounded-lg border-gray-200">
+                <SelectTrigger className="h-8 w-20 text-xs rounded-lg border-gray-200">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/Frontend/src/components/common/email-activity-log/EmpEmailActivityLog.jsx
+++ b/Frontend/src/components/common/email-activity-log/EmpEmailActivityLog.jsx
@@ -119,7 +119,7 @@ const EmpEmailActivityLog = () => {
         <div className="flex items-center gap-2">
           <span className="text-[13px] text-gray-500 font-medium">{t("show")}</span>
           <Select value={String(filters.limit)} onValueChange={handlePageSizeChange}>
-            <SelectTrigger className="h-8 w-16 text-[13px] rounded-lg border-gray-200">
+            <SelectTrigger className="h-8 w-20 text-[13px] rounded-lg border-gray-200">
               <SelectValue placeholder="10" />
             </SelectTrigger>
             <SelectContent className="rounded-xl">

--- a/Frontend/src/components/common/mobile-task-clients/EmpMobileTaskClients.jsx
+++ b/Frontend/src/components/common/mobile-task-clients/EmpMobileTaskClients.jsx
@@ -92,7 +92,7 @@ const EmpMobileTaskClients = () => {
             <div className="flex flex-wrap items-center justify-between gap-4 mb-7">
                 <div className="flex items-center gap-2">
                     <span className="text-[13px] text-[#424242] font-medium">{t("show")}</span>
-                    <Select value={String(pagination.pageSize)} onValueChange={handlePageSizeChange}><SelectTrigger className="h-8 w-16 text-[13px] rounded-lg border-gray-200"><SelectValue placeholder="10" /></SelectTrigger><SelectContent className="rounded-xl">{["10", "25", "50", "100"].map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}</SelectContent></Select>
+                    <Select value={String(pagination.pageSize)} onValueChange={handlePageSizeChange}><SelectTrigger className="h-8 w-20 text-[13px] rounded-lg border-gray-200"><SelectValue placeholder="10" /></SelectTrigger><SelectContent className="rounded-xl">{["10", "25", "50", "100"].map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}</SelectContent></Select>
                     <span className="text-[13px] text-[#424242] font-medium">{t("entries")}</span>
                 </div>
                 <div className="relative w-full max-w-xs"><Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" /><Input placeholder={t("search")} value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9 h-10 rounded-full bg-slate-50 border-slate-200 text-xs" /></div>

--- a/Frontend/src/components/common/mobile-task-details/EmpMobileTaskDetails.jsx
+++ b/Frontend/src/components/common/mobile-task-details/EmpMobileTaskDetails.jsx
@@ -105,7 +105,7 @@ const EmpMobileTaskDetails = () => {
             <div className="flex flex-wrap items-center justify-between gap-4 mb-7">
                 <div className="flex items-center gap-2">
                     <span className="text-[13px] text-[#424242] font-medium">{t("show")}</span>
-                    <Select value={String(pagination.pageSize)} onValueChange={handlePageSizeChange}><SelectTrigger className="h-8 w-16 text-[13px] rounded-lg border-gray-200"><SelectValue placeholder="10" /></SelectTrigger><SelectContent className="rounded-xl">{["10", "25", "50", "100"].map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}</SelectContent></Select>
+                    <Select value={String(pagination.pageSize)} onValueChange={handlePageSizeChange}><SelectTrigger className="h-8 w-20 text-[13px] rounded-lg border-gray-200"><SelectValue placeholder="10" /></SelectTrigger><SelectContent className="rounded-xl">{["10", "25", "50", "100"].map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}</SelectContent></Select>
                     <span className="text-[13px] text-[#424242] font-medium">{t("entries")}</span>
                 </div>
                 <div className="relative w-full max-w-xs"><Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" /><Input placeholder={t("search")} value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9 h-10 rounded-full bg-slate-50 border-slate-200 text-xs" /></div>

--- a/Frontend/src/components/common/web-app-usage/EmpWebAppUsage.jsx
+++ b/Frontend/src/components/common/web-app-usage/EmpWebAppUsage.jsx
@@ -498,7 +498,7 @@ function CustomizeModal() {
               value={String(modalPageSize)}
               onValueChange={(v) => setModalPageSize(parseInt(v, 10))}
             >
-              <SelectTrigger className="h-8 w-16 text-sm rounded-lg border-gray-200">
+              <SelectTrigger className="h-8 w-20 text-sm rounded-lg border-gray-200">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="rounded-xl">
@@ -732,7 +732,7 @@ export default function EmpWebAppUsage() {
             value={String(cTablePageSize)}
             onValueChange={(v) => setCTablePageSize(parseInt(v, 10))}
           >
-            <SelectTrigger className="h-8 w-16 text-[13px] rounded-lg border-gray-200">
+            <SelectTrigger className="h-8 w-20 text-[13px] rounded-lg border-gray-200">
               <SelectValue placeholder="10" />
             </SelectTrigger>
             <SelectContent className="rounded-xl">


### PR DESCRIPTION
## Summary
Closes #87, #88, #101, #102.

Seven page-size Selects used `w-16` (64px) on the `SelectTrigger`. With shadcn/ui defaults (`px-3` padding + `gap-2` + `size-4` chevron), that leaves ~16px for the value text — enough for "10" but truncated for "100". Screenshots on the linked issues confirm the cut-off.

## Fix

Bumped every page-size trigger to `w-20` (80px). One line each across 6 files:

- `components/common/elements/ShowEntries.jsx` — shared pagination size control used by many pages (closes **#101** Roles & Permissions, **#102** Alerts Notifications).
- `components/common/elements/ViewReportModal.jsx` — dashboard "View Report" modal used by Top 10 Productive / Non-Productive cards (closes **#87** and **#88**).
- `components/common/email-activity-log/EmpEmailActivityLog.jsx`
- `components/common/mobile-task-clients/EmpMobileTaskClients.jsx`
- `components/common/mobile-task-details/EmpMobileTaskDetails.jsx`
- `components/common/web-app-usage/EmpWebAppUsage.jsx` (two call sites)

No other class changes, no logic changes.

## Test plan
- [ ] `/admin/roles-permissions` → change entries dropdown to 100 → number visible.
- [ ] `/admin/behaviour/alerts-notifications` → same.
- [ ] Dashboard → Top 10 Productive → View Report modal → entries dropdown → 100 visible.
- [ ] Dashboard → Top 10 Non-Productive → View Report modal → 100 visible.
- [ ] DLP → Email Activity Log → 100 visible.
- [ ] Mobile Task pages → 100 visible.
- [ ] Reports → Web & App Usage → 100 visible in both the main and the detail modal.