### PR TITLE
Fix DLP filter bar overflow on common laptop widths

### DIFF
--- a/Frontend/src/components/common/email-activity-log/EmpEmailActivityLog.jsx
+++ b/Frontend/src/components/common/email-activity-log/EmpEmailActivityLog.jsx
@@ -78,7 +78,7 @@ const EmpEmailActivityLog = () => {
       </div>
 
       {/* Filters */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-x-6 gap-y-4 mb-5">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-6 gap-x-6 gap-y-4 mb-5">
         <div>
           <label className="block text-sm font-medium text-slate-700 mb-1.5">{t("location")}</label>
           <CustomSelect placeholder="All Locations" items={locations} selected={filters.locationId} onChange={handleLocationChange} />

--- a/Frontend/src/components/common/screenshot-logs/EmpScreenshotLogs.jsx
+++ b/Frontend/src/components/common/screenshot-logs/EmpScreenshotLogs.jsx
@@ -61,7 +61,7 @@ const EmpScreenshotLogs = () => {
       </div>
 
       {/* Filters */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-x-6 gap-y-4 mb-5">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5 gap-x-6 gap-y-4 mb-5">
         <div>
           <label className="block text-sm font-medium text-slate-700 mb-1.5">{t("location")}</label>
           <CustomSelect placeholder="All Locations" items={locations} selected={filters.locationId} onChange={handleLocationChange} />

--- a/Frontend/src/components/common/system-logs/EmpSystemLogs.jsx
+++ b/Frontend/src/components/common/system-logs/EmpSystemLogs.jsx
@@ -73,7 +73,7 @@ const EmpSystemLogs = () => {
       </div>
 
       {/* Filters */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-x-6 gap-y-4 mb-5">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5 gap-x-6 gap-y-4 mb-5">
         <div>
           <label className="block text-sm font-medium text-slate-700 mb-1.5">{t("location")}</label>
           <CustomSelect placeholder="All Locations" items={locations} selected={filters.locationId} onChange={handleLocationChange} />

--- a/Frontend/src/components/common/usb-detection/EmpUsbDetection.jsx
+++ b/Frontend/src/components/common/usb-detection/EmpUsbDetection.jsx
@@ -64,7 +64,7 @@ const EmpUsbDetection = () => {
       </div>
 
       {/* Filters */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-x-6 gap-y-4 mb-5">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5 gap-x-6 gap-y-4 mb-5">
         <div>
           <label className="block text-sm font-medium text-slate-700 mb-1.5">{t("location")}</label>
           <CustomSelect placeholder={t("allLocations")} items={locations} selected={filters.locationId} onChange={handleLocationChange} />


### PR DESCRIPTION
## Summary
Closes #95, #96, #97, #98.

All four DLP pages (USB Detection, System Logs, Screenshot Logs, Email Activity Logs) used the same filter-bar grid `xl:grid-cols-5` (Email Activity Log had `xl:grid-cols-6`). The filter controls are fixed-width:

- Location, Department, Employee CustomSelects: `w-44` (176px each)
- DateRangeCalendar trigger: `min-w-[220px]`
- Download CustomSelect: `w-44` (176px)
- (Email Activity Log also has a Type CustomSelect at `w-44`)

At a typical 1360px viewport the card's internal width is ~1008px and five controls + four 24-px gaps add up to ~1020px, so **DateRangeCalendar overflows its cell and visually laps onto the Download column**. Screenshots on the linked issues show exactly that.

## Fix
Push the dense N-column layout from the `xl:` breakpoint (≥1280px) to `2xl:` (≥1536px). At common laptop widths the grid falls back to 3 columns × 2 rows, where every control comfortably fits.

One class per file, same pattern for all four:
- `usb-detection/EmpUsbDetection.jsx` — `xl:grid-cols-5` → `2xl:grid-cols-5`
- `system-logs/EmpSystemLogs.jsx` — same
- `screenshot-logs/EmpScreenshotLogs.jsx` — same
- `email-activity-log/EmpEmailActivityLog.jsx` — `xl:grid-cols-6` → `2xl:grid-cols-6`

No other changes, no logic touched. The DateRangeCalendar component and CustomSelect are unmodified — they still behave the same everywhere else.

## Test plan
- [ ] DLP → USB Detection on 1360×768 → filter controls all visible in 2 rows, no overlap.
- [ ] Same for System Logs, Screenshot Logs, Email Activity Logs.
- [ ] On a ≥1536px wide viewport → filters revert to single-row 5/6-column layout (matches previous behaviour on large monitors).