### PR TITLE
Wire Download and Fullscreen buttons on dashboard cards

### DIFF
--- a/Frontend/src/components/common/elements/Customreport.jsx
+++ b/Frontend/src/components/common/elements/Customreport.jsx
@@ -4,10 +4,28 @@ import { Button } from "@/components/ui/button";
 import { Download, Fullscreen } from "lucide-react";
 import aiVideo from "@/assets/ai.webm";
 
+/**
+ * Walk up the DOM from `start` to the nearest card-looking ancestor
+ * (has a `rounded-*` class alongside `shadow-*` or `border`). Falls back
+ * to the immediate parent if nothing matches.
+ */
+const findCardAncestor = (start) => {
+  let el = start?.parentElement;
+  while (el && el !== document.body) {
+    const cls = typeof el.className === "string" ? el.className : "";
+    if (cls && /\brounded/.test(cls) && /\b(shadow|border)/.test(cls)) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+  return start?.parentElement ?? null;
+};
 
+const slugify = (s) =>
+  (s || "dashboard").toString().trim().toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
 
 const Customreport = ({
-  title ="",
+  title = "",
   showShield = false,
   showButton = false,
   buttonText,
@@ -15,9 +33,12 @@ const Customreport = ({
   showDownload = false,
   onViewReport,
   onAiClick,
+  onMaximize,
+  onDownload,
 }) => {
   const { t } = useTranslation();
   const videoRef = useRef(null);
+  const rootRef = useRef(null);
   const resolvedButtonText = buttonText || t("viewReport");
 
   const handleVideoMouseEnter = useCallback(() => {
@@ -34,8 +55,51 @@ const Customreport = ({
     el.currentTime = 0;
   }, []);
 
+  const handleMaximize = useCallback(async () => {
+    if (onMaximize) return onMaximize();
+    const target = findCardAncestor(rootRef.current);
+    if (!target) return;
+    try {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      } else {
+        await target.requestFullscreen();
+      }
+    } catch (err) {
+      console.error("Fullscreen toggle failed:", err);
+    }
+  }, [onMaximize]);
+
+  const handleDownload = useCallback(async () => {
+    if (onDownload) return onDownload();
+    const target = findCardAncestor(rootRef.current);
+    if (!target) return;
+    try {
+      const { default: html2canvas } = await import("html2canvas");
+      const canvas = await html2canvas(target, {
+        backgroundColor: "#ffffff",
+        scale: 2,
+        useCORS: true,
+        logging: false,
+      });
+      canvas.toBlob((blob) => {
+        if (!blob) return;
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${slugify(title)}-${new Date().toISOString().slice(0, 10)}.png`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }, "image/png");
+    } catch (err) {
+      console.error("Card download failed:", err);
+    }
+  }, [onDownload, title]);
+
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3">
+    <div ref={rootRef} className="flex flex-wrap items-center justify-between gap-3">
       {showShield && (
         <div
           className="w-12 h-12 flex items-center justify-center shrink-0 cursor-pointer"
@@ -66,13 +130,25 @@ const Customreport = ({
       )}
 
       {showMaximize && (
-        <button className="text-slate-400 hover:text-slate-600 transition-colors">
+        <button
+          type="button"
+          onClick={handleMaximize}
+          title="Fullscreen"
+          aria-label="Fullscreen"
+          className="text-slate-400 hover:text-slate-600 transition-colors cursor-pointer"
+        >
           <Fullscreen size={16} />
         </button>
       )}
 
       {showDownload && (
-        <button className="text-slate-400 hover:text-slate-600 transition-colors">
+        <button
+          type="button"
+          onClick={handleDownload}
+          title="Download as image"
+          aria-label="Download as image"
+          className="text-slate-400 hover:text-slate-600 transition-colors cursor-pointer"
+        >
           <Download size={16} />
         </button>
       )}


### PR DESCRIPTION
## Summary
Closes #86, #89, #90.

`Customreport` is the component that renders the Fullscreen + Download icons in every dashboard card header (Today Activity Snapshot, Activity Break Down, Location / Department Performance, Top 10 Productive / Non-Productive, Active / Non-Active Employees, etc.). Both buttons were rendered with the right SVG but had **no `onClick` handler** — clicking did nothing.

## Fix
One-file change: [`components/common/elements/Customreport.jsx`](components/common/elements/Customreport.jsx). Added default `handleMaximize` and `handleDownload` so every caller that passes `showMaximize` / `showDownload` gets working buttons without any per-caller edit.

- **Fullscreen**: walks up the DOM from the button to the nearest card ancestor (element whose className has a `rounded-*` and a `shadow-*` or `border` class — the common dashboard-card signature), then toggles `requestFullscreen()` on it.
- **Download**: same ancestor walk, then `html2canvas` the card to a 2× PNG and trigger a browser download named `<title>-<yyyy-mm-dd>.png`. `html2canvas` is imported dynamically so it stays out of the main bundle.

Callers can still override with explicit `onMaximize` / `onDownload` props if they need custom behaviour.

Also added `type="button"`, `title`, `aria-label`, and `cursor-pointer` for a11y + hover affordance.

## Affected cards (all now work)
- Today Activity Snapshot (`components/common/Snapshot.jsx`)
- Activity Break Down (`components/common/ActivityBreakDown.jsx`)
- Location Performance / Department Performance (admin Dashboard)
- Top 10 Productive / Non-Productive Employees (admin Dashboard)
- Active Employees / Non-Active Employees (admin Dashboard)
- Non-admin Dashboard mirrors

Plus any future caller that passes `showMaximize`/`showDownload`.

## Test plan
- [ ] Dashboard → Today Activity Snapshot → Fullscreen icon → card enters fullscreen; ESC exits.
- [ ] Same card → Download icon → browser downloads a PNG of the card.
- [ ] Repeat for Activity Break Down, Location Performance, Department Performance, Top 10 Productive / Non-Productive.
- [ ] Verify callers that pass `onViewReport` (Top 10 cards) still work — the Fullscreen/Download are independent.
- [ ] Non-admin dashboard shows the same behaviour.