### PR TITLE
Fix notification bell + EMP Cloud return URL

### DIFF
--- a/Frontend/src/components/SSOGate.jsx
+++ b/Frontend/src/components/SSOGate.jsx
@@ -108,8 +108,17 @@ export default function SSOGate({ children }) {
         // Also set the bare token (used by some API interceptors)
         localStorage.setItem('token', accessToken);
 
-        // Remember where to return to in EMP Cloud
-        localStorage.setItem('empcloud_return_url', window.location.origin.replace(/monitor[^.]*/i, 'cloud') + '/dashboard');
+        // Remember where to return to in EMP Cloud.
+        // For empmonitor.empcloud.com → empcloud.com (strip the empmonitor subdomain).
+        // For other hosts (localhost, custom domains) leave unchanged.
+        const host = window.location.host;
+        const empCloudHost = /^empmonitor\./i.test(host)
+          ? host.replace(/^empmonitor\./i, '')
+          : host;
+        localStorage.setItem(
+          'empcloud_return_url',
+          `${window.location.protocol}//${empCloudHost}/dashboard`,
+        );
 
         // Navigate based on role
         const dest = is_admin ? '/admin/dashboard'

--- a/Frontend/src/page/protected/admin/layout/TopBar.jsx
+++ b/Frontend/src/page/protected/admin/layout/TopBar.jsx
@@ -84,10 +84,16 @@ export default function TopHeader() {
         </a>
 
         {/* Notification Bell */}
-        <div className="relative flex h-9 w-9 cursor-pointer items-center justify-center rounded-full shadow-lg  hover:bg-slate-100 transition-colors">
+        <button
+          type="button"
+          onClick={() => navigate("/admin/behaviour/alertnotification")}
+          title={t("alerts")}
+          aria-label={t("alerts")}
+          className="relative flex h-9 w-9 cursor-pointer items-center justify-center rounded-full shadow-lg hover:bg-slate-100 transition-colors"
+        >
           <Bell className="h-5 w-5 text-gray-600" />
           <span className="absolute top-1 right-1.5 h-2 w-2 rounded-full bg-red-500"></span>
-        </div>
+        </button>
 
         {/* Profile Dropdown */}
         <DropdownMenu>

--- a/Frontend/src/page/protected/non-admin/layout/TopBar.jsx
+++ b/Frontend/src/page/protected/non-admin/layout/TopBar.jsx
@@ -121,10 +121,16 @@ export default function NonAdminTopBar() {
           <span className="hidden lg:inline">{t("topbar_help")}</span>
         </button>
 
-        <div className="relative flex h-9 w-9 cursor-pointer items-center justify-center rounded-full shadow-lg hover:bg-slate-100 transition-colors">
+        <button
+          type="button"
+          onClick={() => navigate("/non-admin/behaviour/alertnotification")}
+          title={t("alerts")}
+          aria-label={t("alerts")}
+          className="relative flex h-9 w-9 cursor-pointer items-center justify-center rounded-full shadow-lg hover:bg-slate-100 transition-colors"
+        >
           <Bell className="h-5 w-5 text-gray-600" />
           <span className="absolute top-1 right-1.5 h-2 w-2 rounded-full bg-red-500" />
-        </div>
+        </button>
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary
Closes #84.

Two unrelated bugs reported in the same issue, both in the global topbar.

## 1. Notification bell — not clickable
The bell in `admin/layout/TopBar.jsx` and `non-admin/layout/TopBar.jsx` was rendered as a plain `<div>` with `cursor-pointer` but no `onClick` — clicks did nothing.

**Fix:** swap to a `<button type="button">` with an `onClick` that navigates to the existing alert-notification page (`/admin/behaviour/alertnotification` or `/non-admin/...`). Added `title`, `aria-label`, and kept the same visual classes.

## 2. EMP Cloud return URL — invalid host
`SSOGate.jsx` constructed the cloud URL with:

```js
window.location.origin.replace(/monitor[^.]*/i, 'cloud') + '/dashboard'
```

For the common prod host `empmonitor.empcloud.com` this regex turns `monitor` into `cloud` and produces `empcloud.empcloud.com/dashboard` — an invalid double-`empcloud` subdomain that fails DNS (`DNS_PROBE_FINISHED_NXDOMAIN`).

**Fix:** if the host starts with `empmonitor.`, strip that subdomain. Leave other hosts (localhost, custom domains) alone.

| Input host | Old output | New output |
| --- | --- | --- |
| `empmonitor.empcloud.com` | `empcloud.empcloud.com/dashboard` ❌ | `empcloud.com/dashboard` ✅ |
| `localhost:5174` | `localhost:5174/dashboard` (unchanged via no-match) | same |
| `empmonitor.acme.com` | `empcloud.acme.com/dashboard` (assumes mirror) | `acme.com/dashboard` |

If a customer uses a non-standard layout where the cloud lives at a `cloud.` subdomain instead of bare apex, that would need a backend-driven `return_url` in the SSO response — flagged for follow-up but out of scope here.

## Test plan
- [ ] Open EmpMonitor via SSO from EmpCloud → top-right "EMP Cloud" link → clicking it goes to `empcloud.com/dashboard` (or your equivalent), no DNS error.
- [ ] Click the bell → lands on the Alert Notification page.
- [ ] Same on non-admin login.