### PR TITLE
Fix registerUser to accept plain-text passwords from frontend

### DIFF
--- a/Backend/admin/src/routes/v3/useractivity/useractivity.controller.js
+++ b/Backend/admin/src/routes/v3/useractivity/useractivity.controller.js
@@ -95,9 +95,11 @@ class UserActivity {
             // let manager_role_id = req.body.manager_role_id;
             // let assigned_manager = req.body.assigned_manager;
 
-            if (password && typeof password === 'string' && password.includes(':')) {
-                try { password = PasswordEncodeDecoder.passwordDecrypt(password); } catch (e) { password = null; }
-            } else { password = null; }
+            // Frontend sends plain-text password. The broken include(':') check
+            // that used to live here wiped every plain-text password to null
+            // and guaranteed the validator below rejected it. Same fix as
+            // updateProfile (commit cb1b720). Plain text flows to the
+            // validator, then to encryptText() on line ~131 before DB storage.
             let findMoreLink = {
                 development: process.env.WEB_DEV, production: process.env.WEB_PRODUCTION
             }[process.env.NODE_ENV] || process.env.WEB_LOCAL;


### PR DESCRIPTION
## Summary
Closes #92.

`registerUser` had the same broken password-coercion block that `updateProfile` removed in commit cb1b720:

```js
if (password && typeof password === 'string' && password.includes(':')) {
    try { password = PasswordEncodeDecoder.passwordDecrypt(password); }
    catch (e) { password = null; }
} else { password = null; }
```

The frontend sends plain-text passwords (no `:` separator), so this block always wipes `password` to `null`. The Joi schema on line 52 then rejects it with *"The password must contain at least one special character and at least one number and a minimum of 8 characters."* — even for a clearly-valid password like the one in the issue screenshot (`Raj!@#123455wr34534refs@%^`).

## Fix
Remove the broken block. Plain text flows straight to the validator (which accepts valid passwords) and then to `encryptText()` a few lines down, which encrypts it into the `iv_hex:cipher_hex` form before DB storage — the same path `updateProfile` uses.

The `encriptedpassword` code path on line 128–132 is untouched, so callers that pre-encrypt still work.

## Test plan
- [ ] Open Employees → Register Employee → enter a password matching the rules (≥8 chars, ≥1 digit, ≥1 special). Submit → employee is created, no validator error.
- [ ] Try deliberately-bad passwords (`short`, `noNumbers!`, `n0special`) → the same "must contain …" error is still returned correctly.
- [ ] Log in as the newly-created employee → login succeeds (confirms the password was encrypted and stored, not stored as null).