### PR TITLE
Fix "Failed To Delete Departments" by sending department_id as string

### DIFF
--- a/Frontend/src/page/protected/admin/location-department/service.js
+++ b/Frontend/src/page/protected/admin/location-department/service.js
@@ -198,8 +198,16 @@ export const getDepartmentsByLocation = async (locationId) => {
 
 export const deleteDeptFromLocation = async ({ locationId, departmentId }) => {
     try {
+        // Backend expects department_id as a string (comma-separated IDs supported).
+        // Sending a number crashes the validator at `department_id.split(",")`
+        // and surfaces a misleading "Failed To Delete Departments." error.
         const { data } = await apiService.apiInstance.delete("/location/delete-dept-location", {
-            data: { location_id: locationId, department_id: departmentId },
+            data: {
+                location_id: locationId,
+                department_id: Array.isArray(departmentId)
+                    ? departmentId.map(String).join(",")
+                    : String(departmentId),
+            },
         });
         if (data?.code === 200) {
             return { success: true, message: data.message || "Department removed from location" };


### PR DESCRIPTION
## Summary
Closes #100.

The "remove departments from a location" dialog was reliably failing with `Failed To Delete Departments.` even for departments with no users and no other dependencies.

## Root cause

The backend `/location/delete-dept-location` route runs this in [location.validation.js:80](Backend/admin/src/routes/v3/location/location.validation.js#L80) *before* schema validation:

```js
department_id = department_id ? department_id.split(",") : [];
```

And again in [location.controller.js:377](Backend/admin/src/routes/v3/location/location.controller.js#L377) — to support comma-separated bulk IDs.

The frontend service was sending `department_id` as a **number** (the raw `dept.department_id` value from the list). `number.split` doesn't exist → TypeError → the outer `try/catch` on line 371 swallows it and returns `locationMessages` id `23` → "Failed To Delete Departments." The real error never reaches the user.

## Fix

In `deleteDeptFromLocation` (service), stringify before sending. If a future caller passes an array of IDs, join them with comma so the batch path works too.

```diff
- department_id: departmentId,
+ department_id: Array.isArray(departmentId)
+     ? departmentId.map(String).join(",")
+     : String(departmentId),
```

One-file change, no backend edit, no other behaviour touched.

## Test plan
- [ ] Settings → Manage Location & Department → pick a location row → open "Remove Departments" dialog → select a department with no assigned users → click Remove → department removes cleanly, no error banner.
- [ ] Try removing a department that HAS assigned users → backend should now return the *actual* message (`Unable To Delete, Some User Exists In This Department`, etc.) instead of the generic failure.