### PR TITLE
Fix Location Performance header overlap and row alignment

### DIFF
--- a/Frontend/src/components/common/Location.jsx
+++ b/Frontend/src/components/common/Location.jsx
@@ -234,13 +234,13 @@ export default function LocationPerformance({
             </div>
 
             {/* List */}
-            <div className="flex-1 w-full">
+            <div className="flex-1 w-full min-w-0">
               {/* Column headers */}
-              <div className="flex items-center justify-between px-1 mb-2">
-                <span className="text-slate-500 text-xs font-medium">
-                  {t("default")}
+              <div className="flex items-center justify-between gap-3 px-1 mb-2">
+                <span className="text-slate-500 text-xs font-medium whitespace-nowrap">
+                  {t("location")}
                 </span>
-                <span className="text-slate-500 text-xs font-medium">
+                <span className="text-slate-500 text-xs font-medium whitespace-nowrap">
                   {t("timePercentage")}
                 </span>
               </div>
@@ -258,19 +258,19 @@ export default function LocationPerformance({
                   {rows.map((item, i) => (
                     <div
                       key={`${item.name}-${i}`}
-                      className="flex items-center justify-between py-3.5 px-1 hover:bg-slate-50/60 rounded-lg transition-colors"
+                      className="flex items-center justify-between gap-3 py-3.5 px-1 hover:bg-slate-50/60 rounded-lg transition-colors"
                     >
-                      <div className="flex items-center gap-2.5">
+                      <div className="flex items-center gap-2.5 min-w-0 flex-1">
                         <MapPin size={16} className="text-blue-500 shrink-0" />
-                        <span className="text-slate-700 font-medium text-sm">
+                        <span className="text-slate-700 font-medium text-sm truncate">
                           {item.name}
                         </span>
                       </div>
-                      <div className="flex flex-col items-end gap-0.5">
-                        <span className="text-blue-500 font-semibold text-sm">
+                      <div className="flex flex-col items-end gap-0.5 shrink-0">
+                        <span className="text-blue-500 font-semibold text-sm whitespace-nowrap">
                           {item.hours}
                         </span>
-                        <span className="text-slate-500 text-xs">
+                        <span className="text-slate-500 text-xs whitespace-nowrap">
                           {item.percentage}%
                         </span>
                       </div>


### PR DESCRIPTION
## Summary
Closes #91.

The Location Performance card on the Dashboard was rendering the list column with overlapping text — see the issue screenshot. Two root causes:

1. **Wrong column header key.** The left header used `t("default")` which returns the literal string *"Default"*. That happened to be identical to the only location's name in the demo org (also "Default"), making the overlap even more confusing. Should be `t("location")` = *"Location"*.
2. **Narrow flex column + long header.** `t("timePercentage")` is *"Time / Percentage"* (17 chars). With `flex items-center justify-between` in a narrow container (the card splits with a 288 px map on the left), the right header wrapped onto two lines and the wrap line collided with the left "Default" text.

Side-by-side, Department Performance has no such issue because its right-hand header is *"Time (Hours)"* (12 chars) and fits on one line in the same space.

## Fix ([Location.jsx](Frontend/src/components/common/Location.jsx))

- Left column header → `t("location")`.
- Both column headers get `whitespace-nowrap`, and the header row gets `gap-3` so `justify-between` can't collapse spacing under pressure.
- Row layout:
  - Left block: `min-w-0 flex-1`, location name `truncate` → long names ellipsize instead of overflowing.
  - Right block: `shrink-0`, hours + percentage both `whitespace-nowrap`.

One file, 11/11 lines.

## Test plan
- [ ] Dashboard → Location Performance card → single location with short name → header reads "Location | Time / Percentage", values stack neatly on the right, no overlap.
- [ ] Try an org with a very long location name (≥20 chars) → name truncates with ellipsis; hours/percentage still align to the right.
- [ ] Compare with Department Performance card → visual parity.