### PR TITLE
Show tooltip on DLP Select-Date-Ranges info icon hover

### DIFF
--- a/Frontend/src/components/common/email-activity-log/EmpEmailActivityLog.jsx
+++ b/Frontend/src/components/common/email-activity-log/EmpEmailActivityLog.jsx
@@ -98,7 +98,9 @@ const EmpEmailActivityLog = () => {
         <div>
           <label className="flex items-center gap-1 text-sm font-medium text-slate-700 mb-1.5">
             {t("email_date_ranges")}
-            <Info className="w-3.5 h-3.5 text-blue-500" />
+            <span title={t("dateRangeTooltip")}>
+              <Info className="w-3.5 h-3.5 text-blue-500 cursor-help" />
+            </span>
           </label>
           <div className="relative">
             <DateRangeCalendar

--- a/Frontend/src/components/common/screenshot-logs/EmpScreenshotLogs.jsx
+++ b/Frontend/src/components/common/screenshot-logs/EmpScreenshotLogs.jsx
@@ -77,7 +77,9 @@ const EmpScreenshotLogs = () => {
         <div>
           <label className="flex items-center gap-1 text-sm font-medium text-slate-700 mb-1.5">
             {t("timeclaim.selectDateRanges")} :
-            <Info className="w-3.5 h-3.5 text-blue-500" />
+            <span title={t("dateRangeTooltip")}>
+              <Info className="w-3.5 h-3.5 text-blue-500 cursor-help" />
+            </span>
           </label>
           <div className="relative">
             <DateRangeCalendar

--- a/Frontend/src/components/common/system-logs/EmpSystemLogs.jsx
+++ b/Frontend/src/components/common/system-logs/EmpSystemLogs.jsx
@@ -89,7 +89,9 @@ const EmpSystemLogs = () => {
         <div>
           <label className="flex items-center gap-1 text-sm font-medium text-slate-700 mb-1.5">
             {t("timeclaim.selectDateRanges")} :
-            <Info className="w-3.5 h-3.5 text-blue-500" />
+            <span title={t("dateRangeTooltip")}>
+              <Info className="w-3.5 h-3.5 text-blue-500 cursor-help" />
+            </span>
           </label>
           <div className="relative">
             <DateRangeCalendar

--- a/Frontend/src/components/common/usb-detection/EmpUsbDetection.jsx
+++ b/Frontend/src/components/common/usb-detection/EmpUsbDetection.jsx
@@ -80,7 +80,9 @@ const EmpUsbDetection = () => {
         <div>
           <label className="flex items-center gap-1 text-sm font-medium text-slate-700 mb-1.5">
             {t("timeclaim.selectDateRanges")} :
-            <Info className="w-3.5 h-3.5 text-blue-500" />
+            <span title={t("dateRangeTooltip")}>
+              <Info className="w-3.5 h-3.5 text-blue-500 cursor-help" />
+            </span>
           </label>
           <DateRangeCalendar
             startDate={filters.startDate}

--- a/Frontend/src/i18n/ar.json
+++ b/Frontend/src/i18n/ar.json
@@ -1004,6 +1004,7 @@
   "ts_track_desc": "تتبع ساعات العمل وأوقات الدخول والخروج",
   "ts_select_date_ranges": "اختيار نطاقات التاريخ",
   "ts_date_range_tooltip": "انقر لتحديد تاريخ البداية والنهاية",
+  "dateRangeTooltip": "انقر لتحديد نطاق تاريخ البداية والنهاية.",
   "ts_exporting": "جاري التصدير…",
   "ts_columns": "الأعمدة",
   "ts_select_all": "تحديد الكل",

--- a/Frontend/src/i18n/en.json
+++ b/Frontend/src/i18n/en.json
@@ -997,6 +997,7 @@
   "ts_track_desc": "Track employee working hours, clock-in and clock-out times",
   "ts_select_date_ranges": "Select Date Ranges",
   "ts_date_range_tooltip": "Click to select a start and end date for the timesheet range",
+  "dateRangeTooltip": "Click to select a start and end date range.",
   "ts_exporting": "Exporting…",
   "ts_columns": "Columns",
   "ts_select_all": "Select All",

--- a/Frontend/src/i18n/es.json
+++ b/Frontend/src/i18n/es.json
@@ -999,6 +999,7 @@
   "ts_track_desc": "Rastree las horas de trabajo, entrada y salida de los empleados",
   "ts_select_date_ranges": "Seleccionar rangos de fechas",
   "ts_date_range_tooltip": "Haga clic para seleccionar una fecha de inicio y fin",
+  "dateRangeTooltip": "Haga clic para seleccionar un rango de fechas de inicio y fin.",
   "ts_exporting": "Exportando…",
   "ts_columns": "Columnas",
   "ts_select_all": "Seleccionar todo",

--- a/Frontend/src/i18n/fr.json
+++ b/Frontend/src/i18n/fr.json
@@ -999,6 +999,7 @@
   "ts_track_desc": "Suivez les heures de travail, les heures d'arrivée et de départ",
   "ts_select_date_ranges": "Sélectionner les plages de dates",
   "ts_date_range_tooltip": "Cliquez pour sélectionner une date de début et de fin",
+  "dateRangeTooltip": "Cliquez pour sélectionner une plage de dates de début et de fin.",
   "ts_exporting": "Exportation…",
   "ts_columns": "Colonnes",
   "ts_select_all": "Tout sélectionner",

--- a/Frontend/src/i18n/idn.json
+++ b/Frontend/src/i18n/idn.json
@@ -999,6 +999,7 @@
   "ts_track_desc": "Lacak jam kerja karyawan, waktu masuk dan keluar",
   "ts_select_date_ranges": "Pilih Rentang Tanggal",
   "ts_date_range_tooltip": "Klik untuk memilih tanggal mulai dan akhir",
+  "dateRangeTooltip": "Klik untuk memilih rentang tanggal mulai dan akhir.",
   "ts_exporting": "Mengekspor…",
   "ts_columns": "Kolom",
   "ts_select_all": "Pilih Semua",

--- a/Frontend/src/i18n/pt.json
+++ b/Frontend/src/i18n/pt.json
@@ -999,6 +999,7 @@
   "ts_track_desc": "Acompanhe as horas de trabalho, horários de entrada e saída",
   "ts_select_date_ranges": "Selecionar intervalos de datas",
   "ts_date_range_tooltip": "Clique para selecionar uma data inicial e final",
+  "dateRangeTooltip": "Clique para selecionar um intervalo de datas inicial e final.",
   "ts_exporting": "Exportando…",
   "ts_columns": "Colunas",
   "ts_select_all": "Selecionar tudo",


### PR DESCRIPTION
## Summary
Closes #99.

All four DLP pages (USB Detection, System Logs, Screenshot Logs, Email Activity Logs) render a lucide `<Info>` icon next to the *Select Date Ranges* label with **no hover behaviour** — the icon has no `title` and no wrapping tooltip, so pointing at it does nothing.

## Fix
Wrap the icon in `<span title={t("dateRangeTooltip")}>` so the browser's native tooltip appears on hover, and add `cursor-help` so the pointer hints it's informational. New generic `dateRangeTooltip` key — *"Click to select a start and end date range."* — added to all six locale bundles (en, ar, es, fr, idn, pt).

Timesheet already has a styled popup tooltip (`ts_date_range_tooltip`) using the same concept — kept as-is for now; a future pass could unify both to the styled popup.

## Test plan
- [ ] DLP → USB Detection → hover over the Info icon next to "Select Date Ranges" → native tooltip appears.
- [ ] Same for System Logs, Screenshot Logs, Email Activity Logs.
- [ ] Switch UI language → tooltip text translates.