### PR TITLE
Remove Statistics download buttons from Reseller Dashboard

### DIFF
--- a/Frontend/src/components/common/reseller-dashboard/EmpResellerDashboard.jsx
+++ b/Frontend/src/components/common/reseller-dashboard/EmpResellerDashboard.jsx
@@ -25,8 +25,6 @@ const EmpResellerDashboard = () => {
     const toggleAllStorageAction = useResellerStore((s) => s.toggleAllStorage);
     const clientLoginAction = useResellerStore((s) => s.clientLogin);
     const fetchAssigned = useResellerStore((s) => s.fetchAssignedEmployees);
-    const downloadEmpStats = useResellerStore((s) => s.downloadEmployeeStats);
-    const downloadMgrStats = useResellerStore((s) => s.downloadManagerStats);
     const clearMessages = useResellerStore((s) => s.clearMessages);
 
     useEffect(() => { loadDashboard(); }, []);
@@ -124,8 +122,6 @@ const EmpResellerDashboard = () => {
                     </div>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                    <Button size="sm" className="bg-blue-500 hover:bg-blue-600 text-xs" onClick={downloadEmpStats}>{t("reseller.employeeStatistics")}</Button>
-                    <Button size="sm" className="bg-blue-500 hover:bg-blue-600 text-xs" onClick={downloadMgrStats}>{t("reseller.managerStatistics")}</Button>
                     <Button size="sm" className="bg-blue-500 hover:bg-blue-600 text-xs" onClick={() => setModal("registerModalOpen", true)}>{t("reseller.addClient")}</Button>
                     <Button size="sm" className="bg-blue-500 hover:bg-blue-600 text-xs" onClick={() => setModal("assignModalOpen", true)}>{t("reseller.assignEmployee")}</Button>
                 </div>

--- a/Frontend/src/i18n/ar.json
+++ b/Frontend/src/i18n/ar.json
@@ -1347,8 +1347,6 @@
   "reseller.adding": "جاري الإضافة...",
   "reseller.dashboard": "لوحة التحكم",
   "reseller.manageDesc": "إدارة عملاء الموزعين والتراخيص وتعيينات الموظفين",
-  "reseller.employeeStatistics": "إحصائيات الموظفين",
-  "reseller.managerStatistics": "إحصائيات المديرين",
   "reseller.totalUsers": "إجمالي المستخدمين",
   "reseller.usersAdded": "المستخدمون المضافون",
   "reseller.canAdd": "يمكن الإضافة",

--- a/Frontend/src/i18n/en.json
+++ b/Frontend/src/i18n/en.json
@@ -1340,8 +1340,6 @@
   "reseller.adding": "Adding...",
   "reseller.dashboard": "Dashboard",
   "reseller.manageDesc": "Manage reseller clients, licenses, and employee assignments",
-  "reseller.employeeStatistics": "Employee Statistics",
-  "reseller.managerStatistics": "Manager Statistics",
   "reseller.totalUsers": "Total Users",
   "reseller.usersAdded": "Users Added",
   "reseller.canAdd": "Can Add",

--- a/Frontend/src/i18n/es.json
+++ b/Frontend/src/i18n/es.json
@@ -1342,8 +1342,6 @@
   "reseller.adding": "Agregando...",
   "reseller.dashboard": "Panel de Control",
   "reseller.manageDesc": "Gestionar clientes revendedores, licencias y asignaciones de empleados",
-  "reseller.employeeStatistics": "Estadísticas de Empleados",
-  "reseller.managerStatistics": "Estadísticas de Gerentes",
   "reseller.totalUsers": "Total de Usuarios",
   "reseller.usersAdded": "Usuarios Agregados",
   "reseller.canAdd": "Puede Agregar",

--- a/Frontend/src/i18n/fr.json
+++ b/Frontend/src/i18n/fr.json
@@ -1342,8 +1342,6 @@
   "reseller.adding": "Ajout...",
   "reseller.dashboard": "Tableau de Bord",
   "reseller.manageDesc": "Gérer les clients revendeurs, les licences et les affectations d'employés",
-  "reseller.employeeStatistics": "Statistiques des Employés",
-  "reseller.managerStatistics": "Statistiques des Gestionnaires",
   "reseller.totalUsers": "Total Utilisateurs",
   "reseller.usersAdded": "Utilisateurs Ajoutés",
   "reseller.canAdd": "Peut Ajouter",

--- a/Frontend/src/i18n/idn.json
+++ b/Frontend/src/i18n/idn.json
@@ -1342,8 +1342,6 @@
   "reseller.adding": "Menambahkan...",
   "reseller.dashboard": "Dasbor",
   "reseller.manageDesc": "Kelola klien reseller, lisensi, dan penugasan karyawan",
-  "reseller.employeeStatistics": "Statistik Karyawan",
-  "reseller.managerStatistics": "Statistik Manajer",
   "reseller.totalUsers": "Total Pengguna",
   "reseller.usersAdded": "Pengguna Ditambahkan",
   "reseller.canAdd": "Bisa Ditambah",

--- a/Frontend/src/i18n/pt.json
+++ b/Frontend/src/i18n/pt.json
@@ -1342,8 +1342,6 @@
   "reseller.adding": "Adicionando...",
   "reseller.dashboard": "Painel",
   "reseller.manageDesc": "Gerenciar clientes revendedores, licenças e atribuições de funcionários",
-  "reseller.employeeStatistics": "Estatísticas de Funcionários",
-  "reseller.managerStatistics": "Estatísticas de Gerentes",
   "reseller.totalUsers": "Total de Usuários",
   "reseller.usersAdded": "Usuários Adicionados",
   "reseller.canAdd": "Pode Adicionar",

--- a/Frontend/src/page/protected/admin/reseller-dashboard/resellerStore.js
+++ b/Frontend/src/page/protected/admin/reseller-dashboard/resellerStore.js
@@ -11,8 +11,6 @@ import {
     assignEmployees as assignEmployeesApi,
     getAssignedEmployees,
     deleteAssignedEmployee as deleteAssignedEmployeeApi,
-    downloadEmployeeStatistics,
-    downloadManagerStatistics,
 } from "./service";
 
 export const useResellerStore = create((set, get) => ({
@@ -166,16 +164,6 @@ export const useResellerStore = create((set, get) => ({
         } else {
             set({ error: result.message });
         }
-    },
-
-    downloadEmployeeStats: async () => {
-        const ok = await downloadEmployeeStatistics();
-        if (!ok) set({ error: "Failed to download employee statistics" });
-    },
-
-    downloadManagerStats: async () => {
-        const ok = await downloadManagerStatistics();
-        if (!ok) set({ error: "Failed to download manager statistics" });
     },
 
     openEdit: (client) => {

--- a/Frontend/src/page/protected/admin/reseller-dashboard/service.js
+++ b/Frontend/src/page/protected/admin/reseller-dashboard/service.js
@@ -1,5 +1,4 @@
 import apiService from "@/services/api.service";
-import * as XLSX from "xlsx";
 
 // ─── Dashboard APIs ──────────────────────────────────────────────────────────
 
@@ -180,54 +179,6 @@ const deleteAssignedEmployee = async (employeeId, resellerOrgId) => {
     }
 };
 
-// Controller: employeeStatisticsData()
-// Backend: GET /external/get-employee-statistics
-const downloadEmployeeStatistics = async () => {
-    try {
-        const { data } = await apiService.apiInstance.get("/external/get-employee-statistics");
-        if (data?.code === 200 && Array.isArray(data.data?.data)) {
-            const rows = data.data.data.map((e) => [
-                e.organization_name, e.employee_name, e.email, e.password,
-                e.emp_code, e.created_at?.split("T")[0] || "", e.computer_name, e.mobile_os || "",
-            ]);
-            const headers = ["Company Name", "Employee Name", "Username", "Password", "Employee Code", "Account Creation Date", "Computer Name", "Mobile OS"];
-            const ws = XLSX.utils.aoa_to_sheet([headers, ...rows]);
-            const wb = XLSX.utils.book_new();
-            XLSX.utils.book_append_sheet(wb, ws, "Employee Statistics");
-            XLSX.writeFile(wb, "Employee_Statistics.xlsx");
-            return true;
-        }
-        return false;
-    } catch {
-        return false;
-    }
-};
-
-// Controller: managerStatisticsData()
-// Backend: GET /external/get-manager-statistics
-const downloadManagerStatistics = async () => {
-    try {
-        const { data } = await apiService.apiInstance.get("/external/get-manager-statistics");
-        if (data?.code === 200 && Array.isArray(data.data?.data)) {
-            const rows = data.data.data.map((e) => [
-                e.organization_name, e.username, e.email, e.organization_password,
-                e.organization_created_at?.split("T")[0] || "", e.employee_email,
-                e.employee_password, e.employee_created_at?.split("T")[0] || "",
-                e.assigned_count, e.computer_name, e.mobile_os || "",
-            ]);
-            const headers = ["Company Name", "Company Username", "Company Email", "Password", "Account Creation Date", "Manager Email", "Password", "Account Creation Date", "Employee Accounts", "Computer Name", "Mobile OS"];
-            const ws = XLSX.utils.aoa_to_sheet([headers, ...rows]);
-            const wb = XLSX.utils.book_new();
-            XLSX.utils.book_append_sheet(wb, ws, "Manager Statistics");
-            XLSX.writeFile(wb, "Manager_Statistics.xlsx");
-            return true;
-        }
-        return false;
-    } catch {
-        return false;
-    }
-};
-
 // ─── Settings APIs ───────────────────────────────────────────────────────────
 
 // Controller: resellerGetSettings()
@@ -265,8 +216,6 @@ export {
     assignEmployees,
     getAssignedEmployees,
     deleteAssignedEmployee,
-    downloadEmployeeStatistics,
-    downloadManagerStatistics,
     getResellerSettings,
     saveResellerSettings,
 };


### PR DESCRIPTION
The Employee Statistics and Manager Statistics download buttons in the Reseller Dashboard header were surfacing a generic "Failed to download" error in production (issue #132). Per product direction the feature is being dropped rather than patched.

Removed:
- Both buttons and their selectors in EmpResellerDashboard.jsx
- downloadEmployeeStats / downloadManagerStats store actions
- downloadEmployeeStatistics / downloadManagerStatistics service functions, the writeXlsx / extractHttpError helpers, and the now-unused xlsx import
- reseller.employeeStatistics and reseller.managerStatistics i18n keys across all six locales (en, es, fr, pt, idn, ar)

Backend routes /external/get-employee-statistics and /external/get-manager-statistics are left untouched.

Refs: #132