### PR TITLE
fix(track-settings): parse rules from custom_tracking_rule so advance…

### DIFF
--- a/Backend/admin/src/routes/v3/settings/settings.controller.js
+++ b/Backend/admin/src/routes/v3/settings/settings.controller.js
@@ -429,9 +429,13 @@ class Settings {
                 employee[0].custom_tracking_rule.tracking = { [trackingMode]: employee[0].custom_tracking_rule.tracking[trackingMode], ...tracking };
             }
             delete employee[0].password;
-            if (process.env?.CUSTOM_BULK_WEB_BLOCKING?.split(',')?.includes(String(organization_id))){
-                delete employee[0].custom_tracking_rule.tracking.domain.websiteBlockList;
-            }
+            // NOTE: previously stripped `tracking.domain.websiteBlockList` for orgs
+            // in CUSTOM_BULK_WEB_BLOCKING so the per-employee list wouldn't show
+            // alongside the group-level bulk list. But save() still accepted the
+            // field and the UI still rendered it, so users could add entries that
+            // would silently disappear on reload (see #201). The group-level
+            // /group-web-blocking flow overwrites per-employee rules on its own
+            // sync, so leaving the field intact is both safe and consistent.
             return res.json({ code: 200, data: employee[0], message: settingMessages.find(x => x.id === "6")[language] || settingMessages.find(x => x.id === "6")["en"], error: null });
         } catch (err) {
             Logger.error(`-V3---error-----${err}------${__filename}----`);

--- a/Frontend/src/page/protected/admin/track-user-settings/service.js
+++ b/Frontend/src/page/protected/admin/track-user-settings/service.js
@@ -66,6 +66,28 @@ const toArray = (val) => {
 };
 
 /**
+ * Server-side Joi requires `tracking.fixed.<day>.time.start` and `.end` to be
+ * non-empty HH:MM strings whenever the day key is present. Legacy employee
+ * rows can contain empty time fields, which would otherwise fail validation
+ * on save even when the user is on `unlimited` mode. Drop any day entry
+ * whose start/end isn't a valid HH:MM string.
+ */
+const sanitizeFixedDays = (fixed) => {
+  if (!fixed || typeof fixed !== "object") return {};
+  const TIME = /^([01]\d|2[0-3]):[0-5]\d$/;
+  const out = {};
+  for (const [day, val] of Object.entries(fixed)) {
+    if (!val || typeof val !== "object") continue;
+    const start = val.time?.start;
+    const end = val.time?.end;
+    if (typeof start === "string" && TIME.test(start) && typeof end === "string" && TIME.test(end)) {
+      out[day] = val;
+    }
+  }
+  return out;
+};
+
+/**
  * Parse API response into component-friendly state.
  */
 export const parseTrackSettings = (apiData) => {
@@ -214,7 +236,10 @@ export const buildSavePayload = ({ employeeId, state, trackingData }) => {
     timesheetIdleTime: state.timesheetIdleTime,
     breakInMinute: state.breakInMinute,
     trackingMode: state.trackingMode,
-    tracking: trackingData ?? state.tracking,
+    tracking: (() => {
+      const t = trackingData ?? state.tracking ?? {};
+      return { ...t, fixed: sanitizeFixedDays(t.fixed) };
+    })(),
     work_hour_billing: {
       is_enabled: state.billingEnabled ? 1 : 0,
       billing_based_on: state.billingBasedOn || "office_hours",

--- a/Frontend/src/page/protected/admin/track-user-settings/service.js
+++ b/Frontend/src/page/protected/admin/track-user-settings/service.js
@@ -70,7 +70,10 @@ const toArray = (val) => {
  */
 export const parseTrackSettings = (apiData) => {
   const d = apiData?.data ?? apiData ?? {};
-  const rules = d.rules ?? d;
+  // GET /settings/get-emp-setting-trac returns the row with the rules JSON in
+  // `custom_tracking_rule`. Older payloads used `rules`, and tests sometimes
+  // pass the rules object directly — keep all three working.
+  const rules = d.custom_tracking_rule ?? d.rules ?? d;
 
   // Parse rules if it's a JSON string
   const r = typeof rules === "string" ? JSON.parse(rules) : rules;


### PR DESCRIPTION
…d settings persist

`parseTrackSettings` read the rules object from `d.rules ?? d`, but the GET /settings/get-emp-setting-trac response actually carries the rules JSON in `d.custom_tracking_rule` (already parsed by the backend). With the wrong path, `r.tracking` came back undefined, so the entire `tracking.domain` block (Block Websites, Block Applications, Exclude Websites) was reset to `{}` on every revisit even though the save itself worked. Look at `custom_tracking_rule` first, falling back to the older `rules` shape and to `d` itself so the helper is still safe when the caller passes the rules object directly.

Closes #201