### PR TITLE
fix(employee-profile): remove dead Monitor/Search/Lock/Layers icon bu…

### DIFF
--- a/Frontend/src/page/protected/admin/employee-profile/ProductivityTab.jsx
+++ b/Frontend/src/page/protected/admin/employee-profile/ProductivityTab.jsx
@@ -5,7 +5,6 @@ import * as am5xy from "@amcharts/amcharts5/xy";
 import am5themes_Animated from "@amcharts/amcharts5/themes/Animated";
 import {
   Clock, Activity, TrendingUp, TrendingDown, Minus, BarChart3,
-  Monitor, Search, Lock, Layers,
 } from "lucide-react";
 import { fetchProductivity } from "./service";
 import { secToHMS } from "@/lib/dateTimeUtils";
@@ -58,13 +57,6 @@ function TimelineBar({ days }) {
             {t(item.key)}
           </span>
         ))}
-        <div className="ml-auto flex items-center gap-2">
-          {[Monitor, Search, Lock, Layers].map((Icon, i) => (
-            <button key={i} className="w-8 h-8 rounded-lg bg-gray-50 border border-gray-100 flex items-center justify-center text-gray-500 hover:bg-gray-100 transition-colors">
-              <Icon size={15} />
-            </button>
-          ))}
-        </div>
       </div>
 
       <div>


### PR DESCRIPTION
…ttons

Four icon buttons in the Productivity tab's TimelineBar header rendered with no onClick handler — they showed a hover state but did nothing when clicked. Users reasonably expected them to be functional (jump to screencast / web history / etc.) and reported the bug. There's no documented intent for these buttons and no companion code suggests they were ever wired up; they read as design placeholders that shipped. Remove them and the now-unused imports.

Closes #200