### PR TITLE
fix(bulk-update): align template headers with backend column map

### DIFF
--- a/Frontend/src/components/common/employee-details/BulkRegisterModal.jsx
+++ b/Frontend/src/components/common/employee-details/BulkRegisterModal.jsx
@@ -31,7 +31,9 @@ export default function BulkRegisterModal({ open, onOpenChange, onSuccess }) {
       });
       onSuccess?.();
     } else {
-      setResult({ type: "error", msg: res?.msg || t("emp_bulk_registration_failed") });
+      // Backend returns { code, message, error, data } — prefer the human
+      // message; fall back to the generic translated string only if missing.
+      setResult({ type: "error", msg: res?.message || res?.msg || t("emp_bulk_registration_failed") });
     }
   };
 

--- a/Frontend/src/components/common/employee-details/BulkRegisterModal.jsx
+++ b/Frontend/src/components/common/employee-details/BulkRegisterModal.jsx
@@ -34,6 +34,13 @@ export default function BulkRegisterModal({ open, onOpenChange, onSuccess }) {
       // Backend returns { code, message, error, data } — prefer the human
       // message; fall back to the generic translated string only if missing.
       setResult({ type: "error", msg: res?.message || res?.msg || t("emp_bulk_registration_failed") });
+      // code === -1 → browser-level upload abort (commonly Chromium's
+      // ERR_UPLOAD_FILE_CHANGED, which happens if the user edits and re-saves
+      // the picked XLSX between attempts). Force a fresh selection.
+      if (res?.code === -1) {
+        setFile(null);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      }
     }
   };
 

--- a/Frontend/src/components/common/employee-details/BulkUpdateModal.jsx
+++ b/Frontend/src/components/common/employee-details/BulkUpdateModal.jsx
@@ -35,6 +35,14 @@ export default function BulkUpdateModal({ open, onOpenChange, onSuccess }) {
       // Backend returns { code, message, error, data } — prefer the human
       // message; fall back to the generic translated string only if missing.
       setResult({ type: "error", msg: res?.message || res?.msg || t("emp_bulk_update_failed") });
+      // code === -1 → browser-level upload abort (commonly Chromium's
+      // ERR_UPLOAD_FILE_CHANGED, which happens if the user edits and re-saves
+      // the picked XLSX between attempts). The File handle is now stale and
+      // the next click would fail the same way. Force a fresh selection.
+      if (res?.code === -1) {
+        setFile(null);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      }
     }
   };
 

--- a/Frontend/src/components/common/employee-details/BulkUpdateModal.jsx
+++ b/Frontend/src/components/common/employee-details/BulkUpdateModal.jsx
@@ -78,18 +78,23 @@ export default function BulkUpdateModal({ open, onOpenChange, onSuccess }) {
                 setDownloading(true);
                 try {
                   const employees = await fetchEmployeeList();
-                  const headers = ["First Name", "Last Name", "Full Name", "UserName", "Email",
-                    "Employee ID", "Employee Unique ID", "Last Login", "Location", "Department",
-                    "Role"];
+                  // Header text must exactly match the backend's column map at
+                  // Backend/admin/src/utils/helpers/LanguageTranslate.js
+                  // (bulkRegAndUpdate.en) — case-sensitive. Previously this
+                  // shipped "Employee ID" and "Employee Unique ID", which the
+                  // backend reads as "Employee Code" and "Employee Unique Id",
+                  // so every uploaded row had EmployeeCode/EmployeeUniqueId
+                  // undefined and Joi 400'd with "EmployeeCode is not provided
+                  // for some users." (see #198).
+                  const headers = ["First Name", "Last Name", "Email",
+                    "Employee Code", "Employee Unique Id", "Location",
+                    "Department", "Role"];
                   const rows = employees.map((emp) => [
                     emp.first_name || emp.name || "",
                     emp.last_name || "",
-                    emp.full_name || "",
-                    emp.username || "",
                     emp.email || "",
                     emp.emp_code || "",
                     emp.employee_unique_id || "",
-                    emp.employee_updated_at || "",
                     emp.location || "",
                     emp.department || "",
                     emp.role || (Array.isArray(emp.roles) && emp.roles[0]?.role) || "",

--- a/Frontend/src/components/common/employee-details/BulkUpdateModal.jsx
+++ b/Frontend/src/components/common/employee-details/BulkUpdateModal.jsx
@@ -32,7 +32,9 @@ export default function BulkUpdateModal({ open, onOpenChange, onSuccess }) {
       });
       onSuccess?.();
     } else {
-      setResult({ type: "error", msg: res?.msg || t("emp_bulk_update_failed") });
+      // Backend returns { code, message, error, data } — prefer the human
+      // message; fall back to the generic translated string only if missing.
+      setResult({ type: "error", msg: res?.message || res?.msg || t("emp_bulk_update_failed") });
     }
   };
 

--- a/Frontend/src/page/protected/admin/employee-details/service.js
+++ b/Frontend/src/page/protected/admin/employee-details/service.js
@@ -174,6 +174,27 @@ export const fetchAssignedManagersForEmployee = async (employeeId) => {
   }
 };
 
+/**
+ * If axios has no `error.response`, the request never got an HTTP reply —
+ * usually one of:
+ *   - Chromium ERR_UPLOAD_FILE_CHANGED (the picked file changed on disk
+ *     since the user selected it, e.g. they re-saved the XLSX in Excel
+ *     after a previous failed upload — the stale File handle is rejected
+ *     by the browser before the request leaves)
+ *   - genuine network drop / DNS / CORS
+ * In both cases axios reports a useless "Network Error" string. Return a
+ * sentinel code -1 so the modal can both surface an actionable message
+ * AND clear its file picker for the next attempt.
+ */
+const handleBulkUploadError = (error) => {
+  if (error?.response?.data) return error.response.data;
+  return {
+    code: -1,
+    message:
+      "Could not reach the server. The selected file may have changed on disk — please re-select it and try again.",
+  };
+};
+
 export const bulkRegisterEmployees = async (file) => {
   try {
     const fd = new FormData();
@@ -183,11 +204,8 @@ export const bulkRegisterEmployees = async (file) => {
     });
     return data ?? null;
   } catch (error) {
-    // Axios throws on 4xx/5xx — pass the server's structured error body
-    // through so the modal can surface the real message instead of a
-    // generic "Bulk register failed" fallback.
     console.error("Employee Details: bulkRegisterEmployees error", error);
-    return error?.response?.data ?? { code: 500, message: error?.message };
+    return handleBulkUploadError(error);
   }
 };
 
@@ -200,11 +218,8 @@ export const bulkUpdateEmployees = async (file) => {
     });
     return data ?? null;
   } catch (error) {
-    // Axios throws on 4xx/5xx — pass the server's structured error body
-    // through so the modal can surface the real message instead of a
-    // generic "Bulk update failed" fallback.
     console.error("Employee Details: bulkUpdateEmployees error", error);
-    return error?.response?.data ?? { code: 500, message: error?.message };
+    return handleBulkUploadError(error);
   }
 };
 

--- a/Frontend/src/page/protected/admin/employee-details/service.js
+++ b/Frontend/src/page/protected/admin/employee-details/service.js
@@ -183,8 +183,11 @@ export const bulkRegisterEmployees = async (file) => {
     });
     return data ?? null;
   } catch (error) {
+    // Axios throws on 4xx/5xx — pass the server's structured error body
+    // through so the modal can surface the real message instead of a
+    // generic "Bulk register failed" fallback.
     console.error("Employee Details: bulkRegisterEmployees error", error);
-    return null;
+    return error?.response?.data ?? { code: 500, message: error?.message };
   }
 };
 
@@ -197,8 +200,11 @@ export const bulkUpdateEmployees = async (file) => {
     });
     return data ?? null;
   } catch (error) {
+    // Axios throws on 4xx/5xx — pass the server's structured error body
+    // through so the modal can surface the real message instead of a
+    // generic "Bulk update failed" fallback.
     console.error("Employee Details: bulkUpdateEmployees error", error);
-    return null;
+    return error?.response?.data ?? { code: 500, message: error?.message };
   }
 };
 


### PR DESCRIPTION
The downloaded "User List Template" used "Employee ID" and "Employee Unique ID" as column headers, but the backend's bulkUpdateEmployee controller reads from "Employee Code" and "Employee Unique Id" (see Backend/admin/src/utils/helpers/LanguageTranslate.js → bulkRegAndUpdate.en). XLSX/Joi matching is case-sensitive, so every row arrived with EmployeeCode and EmployeeUniqueId undefined and Joi rejected the upload with "EmployeeCode is not provided for some users. Please check and upload again." Rename the two header strings, drop the columns the backend doesn't read (Full Name, UserName, Last Login) and the corresponding row values, and keep the rest unchanged.

Closes #198