### PR TITLE
fix(alert-policies): show recipient name instead of dash when email i…

### DIFF
--- a/Frontend/src/components/common/alert-policies/EmpAlertPolicies.jsx
+++ b/Frontend/src/components/common/alert-policies/EmpAlertPolicies.jsx
@@ -331,11 +331,25 @@ const EmpAlertPolicies = () => {
                                         <AppliesToCell appliesTo={row.appliesTo} />
                                     </td>
                                     <td className="px-4 py-4">
-                                        {row.recipients.map((r, i) => (
-                                            <span key={i} className="inline-flex items-center px-2.5 py-1 rounded-lg bg-slate-100 text-slate-700 text-[10px] font-medium border border-slate-200 mr-1 mb-1">
-                                                {r.email || "-"}
-                                            </span>
-                                        ))}
+                                        {row.recipients.map((r, i) => {
+                                            // Backend (NotificationRulesModel) hydrates each row to
+                                            // { user_id, name, email }. Some user records have no
+                                            // a_email (desktop-agent auto-created accounts in particular),
+                                            // so falling back straight to "-" hid the name even when it
+                                            // was present. Prefer the name; fall back to email; only
+                                            // show "-" when neither exists.
+                                            const display = (r.name && r.name.trim()) || r.email || "-";
+                                            const tooltip = r.name && r.email ? `${r.name} <${r.email}>` : display;
+                                            return (
+                                                <span
+                                                    key={i}
+                                                    title={tooltip}
+                                                    className="inline-flex items-center px-2.5 py-1 rounded-lg bg-slate-100 text-slate-700 text-[10px] font-medium border border-slate-200 mr-1 mb-1"
+                                                >
+                                                    {display}
+                                                </span>
+                                            );
+                                        })}
                                     </td>
                                     <td className="px-4 py-4">
                                         <div className="flex items-center justify-center gap-2">


### PR DESCRIPTION
…s null

The Recipients column rendered `{r.email || "-"}`, so any recipient whose user record had no `a_email` (commonly desktop-agent auto-created accounts) showed as "-" — even though the backend already hydrates each recipient with `name = first_name + " " + last_name` from the users table (see Backend/admin/.../NotificationRulesModel.js).

Prefer the name, fall back to email, and only show "-" when both are missing. Add a `name <email>` tooltip so the email is still accessible on hover when both fields are present.

Closes #192