### PR TITLE
fix(auto-email-report): harden update path (#212)

### DIFF
--- a/Backend/admin/src/routes/v3/reports/emailreport/emailReports.controller.js
+++ b/Backend/admin/src/routes/v3/reports/emailreport/emailReports.controller.js
@@ -219,16 +219,16 @@ class EmailReportsController {
 
             if ((content.hrms_attendance == '1' || content.attendance == '1') && frequency != 5) return sendResponse(res, 400, null, reportMessage.find(x => x.id === "2")[language] || reportMessage.find(x => x.id === "2")["en"],);
 
-            if (!custom.date && frequency == 5) return sendResponse(res, 400, null, reportMessage.find(x => x.id === "2")[language] || reportMessage.find(x => x.id === "2")["en"],);
+            if (frequency == 5 && !custom?.date) return sendResponse(res, 400, null, reportMessage.find(x => x.id === "2")[language] || reportMessage.find(x => x.id === "2")["en"],);
 
-            if(frequency == 9 && !custom && !custom.time) return sendResponse(res, 400, null, reportMessage.find(x => x.id === "2")[language] || reportMessage.find(x => x.id === "2")["en"],);
-            
+            if (frequency == 9 && !custom?.time) return sendResponse(res, 400, null, reportMessage.find(x => x.id === "2")[language] || reportMessage.find(x => x.id === "2")["en"],);
+
             const [rep] = await EmailReportModel.report(`organization_id=${organization_id} AND id=${email_report_id}`);
             if (!rep) return sendResponse(res, 400, null, reportMessage.find(x => x.id === "7")[language] || reportMessage.find(x => x.id === "7")["en"], null);
 
-            let reportByName = await EmailReportModel.searchByname(name, organization_id);
+            const reportByName = name ? await EmailReportModel.searchByname(name, organization_id) : [];
 
-            if (reportByName?.length && reportByName[0].id !== +email_report_id)
+            if (reportByName?.length && reportByName.every(r => r.id !== +email_report_id))
                 return sendResponse(res, 400, null, reportMessage.find(x => x.id === "5")[language] || reportMessage.find(x => x.id === "5")["en"], null);
 
 

--- a/Backend/admin/src/routes/v3/reports/emailreport/emailReports.model.js
+++ b/Backend/admin/src/routes/v3/reports/emailreport/emailReports.model.js
@@ -69,26 +69,30 @@ class EmailReportsModel {
     }
 
     updateEmailReport(name, frequency, recipients, content, filter_type, email_report_id, report_types, custom, location_ids, shift_ids) {
-        let update = '';
-        if (name) update += `name='${name}'`;
-        if (frequency) { update += update ? `, frequency=${frequency}` : `frequency=${frequency}`; }
-        if (recipients) { update += update ? `, recipients="${recipients}"` : `recipients="${recipients}"`; }
-        if (content) { update += update ? `, content='${content}'` : `content='${content}'`; }
-        if (filter_type) { update += update ? `, filter_type=${filter_type}` : `filter_type=${filter_type}`; }
-        if (report_types) { update += update ? `, report_types='${report_types}'` : `report_types='${report_types}'`; }
-        update += custom ? `, custom='${custom}'` : `, custom=NULL`;
-        if(location_ids?.length) update += ` , location_ids = "${location_ids.length ? location_ids.join(',') : ""}" `
-        if(shift_ids?.length) update += ` , shift_ids = "${shift_ids.length ? shift_ids.join(',') : ""}" `
-        if (!update) {
-            return Promise.resolve()
+        const sets = [];
+        const params = [];
+        if (name) { sets.push('name = ?'); params.push(name); }
+        if (frequency) { sets.push('frequency = ?'); params.push(frequency); }
+        if (recipients) {
+            sets.push('recipients = ?');
+            params.push(Array.isArray(recipients) ? recipients.join(',') : recipients);
         }
-        const query = `
-            UPDATE email_reports
-            SET ${update}
-            WHERE id=${email_report_id}
-        `;
+        if (content) { sets.push('content = ?'); params.push(content); }
+        if (filter_type) { sets.push('filter_type = ?'); params.push(filter_type); }
+        if (report_types) {
+            sets.push('report_types = ?');
+            params.push(Array.isArray(report_types) ? report_types.join(',') : report_types);
+        }
+        sets.push('custom = ?');
+        params.push(custom || null);
+        if (location_ids?.length) { sets.push('location_ids = ?'); params.push(location_ids.join(',')); }
+        if (shift_ids?.length) { sets.push('shift_ids = ?'); params.push(shift_ids.join(',')); }
 
-        return mySql.query(query)
+        if (sets.length === 0) return Promise.resolve();
+
+        params.push(email_report_id);
+        const query = `UPDATE email_reports SET ${sets.join(', ')} WHERE id = ?`;
+        return mySql.query(query, params);
     }
 
     deleteUserFromReport(employees, email_report_id = null) {


### PR DESCRIPTION
## Summary
Fixes [#212](https://github.com/EmpCloud/emp-monitor/issues/212) — Auto Email Report → Edit → Update was returning a generic error and failing to persist. Three real bugs sit in the update path:

- **`editReport` validation crashes on `custom: null`.** The Joi schema allows `custom` to be null, but the controller then does `if (!custom.date ...)` and `if (... && !custom.time)` — both dereference a null `custom` and throw a `TypeError`, which the surrounding `try/catch` swallows into a generic 400. Reordered the guards behind `frequency` and switched to optional chaining (`custom?.date`, `custom?.time`). Also corrected the broken `&&` short-circuit in the freq=9 check.
- **Duplicate-name check rejects unchanged-name edits.** The "name already exists" guard only inspected `reportByName[0].id`, so if MySQL returned the self-row second the controller treated it as a collision. Switched to `.every(...)` over all matching rows; also skip the lookup entirely when `name` is omitted (it is optional in the edit schema).
- **`updateEmailReport` SQL breaks on quotes.** The UPDATE was built by string-interpolating raw user input, so a report whose name contains an apostrophe (e.g. `Bob's Report`) or a recipient with a double quote produced invalid SQL and the controller fell through to its generic 400 handler. Rewrote it to mysql2-style parameterized queries (`?` placeholders + params array), which the rest of the model already uses elsewhere.

## Test plan
- [ ] Manually edit an existing auto-email report (title-only change) and confirm Update saves without error.
- [ ] Edit a report whose name contains an apostrophe and confirm Update succeeds (previously broke SQL).
- [ ] Edit a report with `frequency = Time (9)` — both the happy path (time set) and the validation path (time missing) should resolve cleanly without a stack trace.
- [ ] Edit a report with `frequency = Date (5)` and confirm the date-required guard still fires when the user hasn't picked a date.
- [ ] Edit two reports that happen to share a name (or rapid-fire same-name edits) and confirm the duplicate-name guard no longer falsely rejects the unchanged name.