### PR TITLE
fix(employee-details): persist & display profile image on save (#214)

### DIFF
--- a/Frontend/src/components/common/employee-details/EditEmployeeModal.jsx
+++ b/Frontend/src/components/common/employee-details/EditEmployeeModal.jsx
@@ -8,7 +8,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useEmployeeForm, TIMEZONES } from "./useEmployeeForm";
 import EmployeeFormBody from "./EmployeeFormBody";
-import { getEmployeeDetails, editEmployee } from "@/page/protected/admin/employee-details/service";
+import { getEmployeeDetails, editEmployee, uploadEmployeeProfilePic } from "@/page/protected/admin/employee-details/service";
 
 export default function EditEmployeeModal({ open, onOpenChange, employeeId, locations = [], roles = [], shifts = [], onSuccess }) {
   const { t } = useTranslation();
@@ -18,6 +18,7 @@ export default function EditEmployeeModal({ open, onOpenChange, employeeId, loca
   const [loadingDetails, setLoadingDetails] = useState(false);
   const [status, setStatus] = useState(null);
   const [originalUid, setOriginalUid] = useState("");
+  const [existingPhoto, setExistingPhoto] = useState("");
 
   const { form, set, reset, errors, setErrors, departments, deptLoading, validate, buildFormData } = useEmployeeForm(locations);
 
@@ -31,6 +32,7 @@ export default function EditEmployeeModal({ open, onOpenChange, employeeId, loca
       const d = res?.data;
       if (!d) return;
       setOriginalUid(d.uid ?? "");
+      setExistingPhoto(d.photo_path ?? "");
 
       const tzMatch = TIMEZONES.find((tz) => tz.value.startsWith(d.timezone ?? ""))?.value ?? "";
 
@@ -65,12 +67,19 @@ export default function EditEmployeeModal({ open, onOpenChange, employeeId, loca
     setStatus(null);
     const fd = buildFormData({ userId: employeeId, uid: originalUid });
     const res = await editEmployee(fd);
-    setSubmitting(false);
     if (res?.code === 200) {
+      // /user/user-profile-update is JSON-only and preserves the existing
+      // photo_path; the picked file has to go to the dedicated multer endpoint
+      // separately so the avatar actually updates.
+      if (form.profilePicture) {
+        await uploadEmployeeProfilePic(employeeId, form.profilePicture);
+      }
+      setSubmitting(false);
       setStatus({ type: "success", msg: t("emp_updated_successfully") });
       onSuccess?.();
       setTimeout(() => { onOpenChange(false); setStatus(null); }, 1200);
     } else {
+      setSubmitting(false);
       const errMsg = res?.error || res?.message || res?.msg || res?.data?.message || t("emp_update_failed");
       const errLower = (errMsg || "").toLowerCase();
       const fieldErrors = {};
@@ -95,7 +104,7 @@ export default function EditEmployeeModal({ open, onOpenChange, employeeId, loca
   };
 
   const handleClose = (open) => {
-    if (!open) { reset(); setStatus(null); }
+    if (!open) { reset(); setStatus(null); setExistingPhoto(""); }
     onOpenChange(open);
   };
 
@@ -140,6 +149,7 @@ export default function EditEmployeeModal({ open, onOpenChange, employeeId, loca
               showConfirmPassword={showConfirmPassword} setShowConfirmPassword={setShowConfirmPassword}
               locations={locations} roles={roles} shifts={shifts}
               departments={departments} deptLoading={deptLoading}
+              existingPhoto={existingPhoto}
               isEdit
             />
           </>

--- a/Frontend/src/components/common/employee-details/EmployeeDetails.jsx
+++ b/Frontend/src/components/common/employee-details/EmployeeDetails.jsx
@@ -41,11 +41,22 @@ const avatarColors = [
   "bg-orange-400", "bg-rose-500", "bg-teal-500", "bg-cyan-500",
 ];
 
-const RowAvatar = ({ name, idx }) => {
+const RowAvatar = ({ name, idx, photo }) => {
   const color = avatarColors[idx % avatarColors.length];
+  const initial = (name || "?").charAt(0).toUpperCase();
+  // photo_path may be a `/default/profilePic/...` placeholder — fall back to
+  // the colored initial in that case so we don't show the same user.png for
+  // every employee.
+  const isReal = photo && !/\/default\/profilePic\//i.test(photo);
+  if (isReal) {
+    return (
+      <img src={photo} alt={initial}
+        className="w-7 h-7 rounded-full object-cover flex-shrink-0 border border-gray-200" />
+    );
+  }
   return (
     <div className={`w-7 h-7 rounded-full ${color} flex items-center justify-center text-white text-xs font-bold flex-shrink-0`}>
-      {(name || "?").charAt(0).toUpperCase()}
+      {initial}
     </div>
   );
 };
@@ -393,7 +404,7 @@ export default function EmployeeDetailsTable({
                   <TableCell className="pl-3 py-2.5">
                     <div className="flex items-center gap-2 cursor-pointer group"
                       onClick={() => navigate(`${employeeProfilePath}?id=${emp.id}`, { state: { employee: emp } })}>
-                      <RowAvatar name={emp.name} idx={idx} />
+                      <RowAvatar name={emp.name} idx={idx} photo={emp.photoPath} />
                       <span className="text-[13px] font-medium text-gray-700 whitespace-nowrap group-hover:text-blue-600 group-hover:underline transition-colors">
                         {emp.name}
                       </span>

--- a/Frontend/src/components/common/employee-details/EmployeeFormBody.jsx
+++ b/Frontend/src/components/common/employee-details/EmployeeFormBody.jsx
@@ -1,7 +1,7 @@
 /**
  * Shared form fields used by both RegisterEmployeeModal and EditEmployeeModal.
  */
-import { useRef } from "react";
+import { useRef, useEffect, useMemo } from "react";
 import { Eye, EyeOff, Info, ImagePlus } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -29,10 +29,25 @@ export default function EmployeeFormBody({
   showConfirmPassword, setShowConfirmPassword,
   locations = [], roles = [], shifts = [],
   departments = [], deptLoading = false,
+  existingPhoto = "",
   isEdit = false,
 }) {
   const { t } = useTranslation();
   const fileInputRef = useRef(null);
+
+  // Build a thumbnail src: prefer a freshly-picked File (object URL), else the
+  // existing photo_path returned by the backend. The URL is created during
+  // render so we don't trigger a setState-in-effect, and revoked when the File
+  // reference changes or the component unmounts.
+  const pickedPreview = useMemo(
+    () => (form.profilePicture instanceof File ? URL.createObjectURL(form.profilePicture) : ""),
+    [form.profilePicture],
+  );
+  useEffect(() => {
+    if (!pickedPreview) return undefined;
+    return () => URL.revokeObjectURL(pickedPreview);
+  }, [pickedPreview]);
+  const previewSrc = pickedPreview || existingPhoto || "";
 
   return (
     <div className="px-8 pt-6 pb-2 space-y-5">
@@ -198,8 +213,12 @@ export default function EmployeeFormBody({
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-5 gap-y-5">
         <Field label={t("emp_profile_picture")} extra={<Info size={14} className="text-blue-500 inline ml-1" />}>
           <div onClick={() => fileInputRef.current?.click()}
-            className="relative h-11 rounded-xl border border-gray-300 bg-white flex items-center px-5 cursor-pointer hover:border-blue-300 transition-colors">
-            <span className="text-[13px] text-gray-400 flex-1 truncate">
+            className="relative h-11 rounded-xl border border-gray-300 bg-white flex items-center px-2 cursor-pointer hover:border-blue-300 transition-colors gap-2">
+            {previewSrc ? (
+              <img src={previewSrc} alt=""
+                className="w-8 h-8 rounded-full object-cover flex-shrink-0 border border-gray-200" />
+            ) : null}
+            <span className="text-[13px] text-gray-400 flex-1 truncate pl-1">
               {form.profilePicture ? form.profilePicture.name : t("emp_choose_file")}
             </span>
             <div className="w-8 h-8 rounded-xl bg-blue-50 flex items-center justify-center ml-2">

--- a/Frontend/src/components/common/employee-details/RegisterEmployeeModal.jsx
+++ b/Frontend/src/components/common/employee-details/RegisterEmployeeModal.jsx
@@ -8,7 +8,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useEmployeeForm } from "./useEmployeeForm";
 import EmployeeFormBody from "./EmployeeFormBody";
-import { registerEmployee } from "@/page/protected/admin/employee-details/service";
+import { registerEmployee, uploadEmployeeProfilePic } from "@/page/protected/admin/employee-details/service";
 
 export default function RegisterEmployeeModal({ open, onOpenChange, locations = [], roles = [], shifts = [], onSuccess }) {
   const { t } = useTranslation();
@@ -24,13 +24,21 @@ export default function RegisterEmployeeModal({ open, onOpenChange, locations = 
     setSubmitting(true);
     setStatus(null);
     const res = await registerEmployee(buildFormData());
-    setSubmitting(false);
     if (res?.code === 200) {
+      // The register endpoint is JSON-only and can't accept the picked file.
+      // The controller assigns the new employee id to req.body.user_id before
+      // echoing it back, so use that to drive the dedicated avatar upload.
+      const newUserId = res?.data?.user_id ?? res?.data?.userId;
+      if (form.profilePicture && newUserId) {
+        await uploadEmployeeProfilePic(newUserId, form.profilePicture);
+      }
+      setSubmitting(false);
       setStatus({ type: "success", msg: t("emp_registered_successfully") });
       reset();
       onSuccess?.();
       setTimeout(() => { onOpenChange(false); setStatus(null); }, 1200);
     } else {
+      setSubmitting(false);
       const errMsg = res?.error || res?.message || res?.msg || res?.data?.message || t("emp_registration_failed");
       const errLower = (errMsg || "").toLowerCase();
       const fieldErrors = {};

--- a/Frontend/src/page/protected/admin/employee-details/service.js
+++ b/Frontend/src/page/protected/admin/employee-details/service.js
@@ -43,6 +43,31 @@ export const editEmployee = async (formData) => {
   }
 };
 
+/**
+ * Upload an employee profile picture.
+ *
+ * The v3 `/user/user-profile-update` endpoint is JSON-only and ignores any
+ * uploaded file (the controller preserves the existing `photo_path`). Pictures
+ * must go through this dedicated multer endpoint, which writes the file to
+ * cloud storage and updates `users.photo_path`. Field name is `avatar` and the
+ * user id is passed as a query parameter — match the backend exactly.
+ */
+export const uploadEmployeeProfilePic = async (userId, file) => {
+  if (!userId || !file) return null;
+  try {
+    const fd = new FormData();
+    fd.append("avatar", file);
+    const { data } = await apiService.apiInstance.post(
+      `/user/upload-profilepic-drive?user_id=${encodeURIComponent(userId)}`,
+      fd,
+    );
+    return data ?? null;
+  } catch (error) {
+    console.error("Employee Details: uploadEmployeeProfilePic error", error);
+    return error?.response?.data ?? { code: 500, message: error?.message || "Profile picture upload failed." };
+  }
+};
+
 export const deleteEmployee = async (userId) => {
   try {
     const { data } = await apiService.apiInstance.delete("/user/user-delete-multiple", {
@@ -362,6 +387,7 @@ export const mapEmployeeForTable = (emp, idx = 0) => {
     empCode: emp.emp_code || "-",
     os: emp.system_architecture || "Windows",
     computer: emp.computer_name || emp.username || "N/A",
-    version: emp.software_version || "N/A"
+    version: emp.software_version || "N/A",
+    photoPath: emp.photo_path || ""
   };
 };

--- a/Frontend/src/page/protected/admin/employee-profile/ProfileHeader.jsx
+++ b/Frontend/src/page/protected/admin/employee-profile/ProfileHeader.jsx
@@ -6,6 +6,8 @@ import { useLocation, useNavigate } from "react-router-dom";
 export default function ProfileHeader({ employee, startDate, endDate, onDateChange, showActions = true, onEdit }) {
   const { t } = useTranslation();
   const name = employee?.name || t("employee");
+  const photo = employee?.photo_path || employee?.photoPath || "";
+  const hasRealPhoto = photo && !/\/default\/profilePic\//i.test(photo);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -35,9 +37,14 @@ export default function ProfileHeader({ employee, startDate, endDate, onDateChan
               padding: "3px",
             }}
           >
-            <div className="w-full h-full rounded-full bg-gradient-to-br from-violet-600 to-blue-500 flex items-center justify-center text-white text-2xl font-bold">
-              {name.charAt(0).toUpperCase()}
-            </div>
+            {hasRealPhoto ? (
+              <img src={photo} alt={name}
+                className="w-full h-full rounded-full object-cover bg-white" />
+            ) : (
+              <div className="w-full h-full rounded-full bg-gradient-to-br from-violet-600 to-blue-500 flex items-center justify-center text-white text-2xl font-bold">
+                {name.charAt(0).toUpperCase()}
+              </div>
+            )}
           </div>
         </div>
         <div className="min-w-0">

--- a/Frontend/src/page/protected/non-admin/employee-details/service.js
+++ b/Frontend/src/page/protected/non-admin/employee-details/service.js
@@ -53,10 +53,11 @@ export const mapEmployeeForTable = (emp, idx = 0) => ({
   role:
     emp.role ||
     (Array.isArray(emp.roles) && emp.roles.length ? emp.roles[0].role : "Employee"),
-  empCode:  emp.emp_code || "-",
-  os:       emp.system_architecture || "Windows",
-  computer: emp.computer_name || emp.username || "N/A",
-  version:  emp.software_version || "N/A",
+  empCode:   emp.emp_code || "-",
+  os:        emp.system_architecture || "Windows",
+  computer:  emp.computer_name || emp.username || "N/A",
+  version:   emp.software_version || "N/A",
+  photoPath: emp.photo_path || "",
 });
 
 export { fetchFilterOptions } from "../../admin/employee-details/service";


### PR DESCRIPTION
Fixes #214

## Summary
- `useEmployeeForm.buildFormData` returned a JSON payload that dropped the picked `profilePicture` File entirely. `/user/user-profile-update` is JSON-only and preserves `photo_path` — backend exposes a separate multer endpoint `POST /user/upload-profilepic-drive?user_id=...` (field `avatar`) that wasn't wired up.
- After a successful register/edit, the picked file is now POSTed to that endpoint with the resulting `user_id`. The mapped row carries `photo_path` so the table avatar / profile header / edit modal preview render the real image, falling back to the colored initial for missing or default photos.

## Files changed
- `Frontend/src/page/protected/admin/employee-details/service.js` — new `uploadEmployeeProfilePic(userId, file)` helper; `mapEmployeeForTable` now carries `photoPath`.
- `Frontend/src/components/common/employee-details/RegisterEmployeeModal.jsx` / `EditEmployeeModal.jsx` — after the JSON save returns 200, if a file was picked, upload it via the dedicated endpoint.
- `Frontend/src/components/common/employee-details/EmployeeFormBody.jsx` — live thumbnail of picked-or-existing image next to the file picker.
- `Frontend/src/components/common/employee-details/EmployeeDetails.jsx` `RowAvatar` and `Frontend/src/page/protected/admin/employee-profile/ProfileHeader.jsx` — render the real photo when present, fall back to colored initial for `/default/profilePic/...` placeholders or missing photos.
- `Frontend/src/page/protected/non-admin/employee-details/service.js` — same `photoPath` mapping for the shared table.

## Test plan
- [ ] Edit an employee, pick a JPG/PNG, click "Save Changes" → request to `/user/upload-profilepic-drive?user_id=<id>` is sent with the `avatar` field; new image renders in the table row avatar after the modal closes and the list refreshes.
- [ ] Register a new employee with a profile picture → image is uploaded after register, visible after refresh.
- [ ] Re-open Edit for an employee that already has a photo → thumbnail of the existing photo appears next to the file picker (before any new pick).
- [ ] Employee profile page header shows the real photo for users with a saved image, colored initial for users without.
- [ ] Saving without picking a file does NOT trigger any upload request (no regression on the basic edit flow).
- [ ] `npm run lint` and `npm run build` both pass on changed files.