### PR TITLE
fix(admin-login): remove page-wide sky tint overlay

### DIFF
--- a/Frontend/src/page/auth/admin-login/index.jsx
+++ b/Frontend/src/page/auth/admin-login/index.jsx
@@ -114,9 +114,6 @@ export const AdminLogin = () => {
         backgroundRepeat: "no-repeat",
       }}
     >
-      {/* Subtle tint overlay */}
-      <div className="absolute inset-0 bg-sky-50/20 pointer-events-none z-0" />
-
       {/* ── Header ────────────────────────────────────────────────────── */}
       <header className="animate-fade-down relative z-10 flex items-center justify-between px-8 py-5">
         <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

The admin-login page rendered a full-viewport `bg-sky-50/20` div over the background illustration. That tint washed out everything outside the form card — illustration, header logo, even the negative space.

Removed the overlay. The form card's own frosted-glass effect (`backdrop-filter: blur(24px)` + `rgba(255,255,255,0.92)`) is preserved — that's the intended design and only affects whatever sits behind the card.

**Before**: whole page faded under a pale-blue wash.
**After**: illustration renders crisp; only the form card has the soft frosted background.

1 file changed, 3 deletions.

## Test plan

- [ ] Visit `/admin-login`
- [ ] Illustration on the left renders at full saturation (no blue wash)
- [ ] Form card still shows the frosted-glass effect against the illustration
- [ ] Inputs, focus states, error banner, forgot-password dialog all unchanged