### PR TITLE
fix(employee-comparison): replace dummy zeros with real unproductive/neutral data

### DIFF
--- a/Frontend/src/components/common/employee-comparison/ProductivityComp.jsx
+++ b/Frontend/src/components/common/employee-comparison/ProductivityComp.jsx
@@ -253,17 +253,26 @@ const ProductivityComp = () => {
     fetchStats()
   }, [rightEmployee, rightDateFrom, rightDateTo])
 
+  const pctOfOffice = (stats, seconds) => {
+    const office = Number(stats?.officeSeconds || 0)
+    if (!office) return 0
+    const pct = (Number(seconds || 0) / office) * 100
+    return Math.min(100, Math.max(0, pct))
+  }
+
   const buildChartData = (stats) => {
     if (!stats) return BASE_CHART_DATA
 
-    const p = Number(stats.productivityPercentValue || 0)
-    const productive = Math.min(100, Math.max(0, p))
-    const unproductive = Math.max(0, 100 - productive)
+    const productive = pctOfOffice(stats, stats.productiveSeconds)
+    const unproductive = pctOfOffice(stats, stats.unproductiveSeconds)
+    const neutral = pctOfOffice(stats, stats.neutralSeconds)
+    const other = Math.max(0, 100 - productive - unproductive - neutral)
 
     return BASE_CHART_DATA.map((item) => {
       if (item.name === "Productive") return { ...item, value: productive }
       if (item.name === "Unproductive") return { ...item, value: unproductive }
-      return { ...item, value: 0 }
+      if (item.name === "Neutral") return { ...item, value: neutral }
+      return { ...item, value: other }
     })
   }
 
@@ -271,13 +280,21 @@ const ProductivityComp = () => {
     if (!stats) return BASE_LEGEND_ITEMS
 
     const productive = Number(stats.productivityPercentValue || 0)
-    const unproductive = Math.max(0, 100 - productive)
+    const unproductive = pctOfOffice(stats, stats.unproductiveSeconds)
+    const neutral = pctOfOffice(stats, stats.neutralSeconds)
+    const other = Math.max(
+      0,
+      100 -
+        pctOfOffice(stats, stats.productiveSeconds) -
+        unproductive -
+        neutral
+    )
 
     return [
       { ...BASE_LEGEND_ITEMS[0], value: `${productive.toFixed(2)}%` },
       { ...BASE_LEGEND_ITEMS[1], value: `${unproductive.toFixed(2)}%` },
-      BASE_LEGEND_ITEMS[2],
-      BASE_LEGEND_ITEMS[3],
+      { ...BASE_LEGEND_ITEMS[2], value: `${neutral.toFixed(2)}%` },
+      { ...BASE_LEGEND_ITEMS[3], value: `${other.toFixed(2)}%` },
     ]
   }
 
@@ -289,8 +306,12 @@ const ProductivityComp = () => {
       switch (idx) {
         case 0:
           return { ...item, value: stats.officeTime }
+        case 1:
+          return { ...item, value: stats.unproductiveTime }
         case 2:
           return { ...item, value: stats.activeTime }
+        case 3:
+          return { ...item, value: stats.neutralTime }
         case 4:
           return { ...item, value: stats.productiveTime }
         case 5:

--- a/Frontend/src/page/protected/admin/employee-comparison/service.js
+++ b/Frontend/src/page/protected/admin/employee-comparison/service.js
@@ -130,6 +130,18 @@ export const getEmployeeProductivity = async ({
             data?.production_data ||
             {};
 
+        // Per-date rows carry non_productive_duration / neutral_duration; the
+        // aggregated `production_data` block doesn't, so sum them here.
+        const daily = Array.isArray(data?.data) ? data.data : [];
+        const unproductiveSeconds = daily.reduce(
+            (s, d) => s + Number(d?.non_productive_duration || 0),
+            0
+        );
+        const neutralSeconds = daily.reduce(
+            (s, d) => s + Number(d?.neutral_duration || 0),
+            0
+        );
+
         const officeSeconds = Number(
             p.total_office_time ??
             p.office_time ??
@@ -151,6 +163,8 @@ export const getEmployeeProductivity = async ({
         const officeTime = formatSecondsToHMS(officeSeconds);
         const activeTime = formatSecondsToHMS(activeSeconds);
         const productiveTime = formatSecondsToHMS(productiveSeconds);
+        const unproductiveTime = formatSecondsToHMS(unproductiveSeconds);
+        const neutralTime = formatSecondsToHMS(neutralSeconds);
 
         const productivityPercent = Number(
             p.total_productivity ??
@@ -163,13 +177,15 @@ export const getEmployeeProductivity = async ({
                 officeTime,
                 activeTime,
                 productiveTime,
+                unproductiveTime,
+                neutralTime,
                 productivityPercent: `${productivityPercent.toFixed(2)}%`,
                 productivityPercentValue: productivityPercent,
                 officeSeconds,
                 activeSeconds,
                 productiveSeconds,
-                unproductiveSeconds: 0,
-                neutralSeconds: 0
+                unproductiveSeconds,
+                neutralSeconds
             },
             raw: data
         };


### PR DESCRIPTION
Closes #215

## Summary
- `getEmployeeProductivity` now sums `non_productive_duration` and `neutral_duration` from the per-date rows the backend already returns (they're missing from the aggregated `production_data` block) and exposes them as `unproductiveTime`/`neutralTime`/`unproductiveSeconds`/`neutralSeconds`.
- `buildChartData`, `buildLegendItems`, and `buildTimeStats` now fill the Unproductive/Neutral/Other slots from the real per-employee values instead of leaving them at the placeholder `00:00:00 hrs` / `0.00%`. Donut percentages use `officeSeconds` as the denominator so the four slices sum to 100%.

The two columns' state, effects, and API calls were already keyed independently (`leftEmployee` vs `rightEmployee`), so no state-isolation change was needed.

## Test plan
- [ ] Open the Employee Comparison tab as an admin.
- [ ] Select two different employees with different activity profiles and confirm the Unproductive, Neutral, and Other legend / donut slices / stat cards now differ between the two columns.
- [ ] Select the same employee on both sides and confirm both columns match.
- [ ] Select an employee with no activity in the range and confirm the "No activity data" empty state still renders.
- [ ] Change the date range on one side only and confirm the other side is unaffected