### PR TITLE
fix(assign-manager): use selected role name in dialog title, label, and placeholder

### DIFF
--- a/Frontend/src/components/common/employee-details/AssignManagerDialog.jsx
+++ b/Frontend/src/components/common/employee-details/AssignManagerDialog.jsx
@@ -55,6 +55,11 @@ export default function AssignManagerDialog({
     [nonAdmins, roleId],
   );
 
+  const selectedRoleLabel = useMemo(
+    () => roles.find((r) => r.value === roleId)?.label || "",
+    [roles, roleId],
+  );
+
   const handleRoleChange = (next) => {
     setRoleId(next);
     setManagerId("");
@@ -95,7 +100,9 @@ export default function AssignManagerDialog({
           </div>
           <div className="flex-1 min-w-0">
             <h3 className="text-[16px] font-bold text-gray-800">
-              {t("emp_assign_manager")}
+              {selectedRoleLabel
+                ? t("emp_assign_role_value", { role: selectedRoleLabel })
+                : t("emp_assign_manager")}
             </h3>
             <p className="text-[12px] text-gray-500 mt-0.5">
               {t("emp_assign_manager_to_count", { count: userIds.length })}
@@ -130,11 +137,17 @@ export default function AssignManagerDialog({
 
           <div className="space-y-2">
             <label className="text-[13px] font-semibold text-gray-700">
-              {t("emp_manager")}
+              {selectedRoleLabel || t("emp_manager")}
             </label>
             <Select value={managerId} onValueChange={setManagerId} disabled={!roleId || submitting}>
               <SelectTrigger className="h-10 rounded-xl border-gray-200 text-[13px]">
-                <SelectValue placeholder={!roleId ? t("emp_select_role_first") : t("emp_select_manager")} />
+                <SelectValue
+                  placeholder={
+                    !roleId
+                      ? t("emp_select_role_first")
+                      : t("emp_select_role_value", { role: selectedRoleLabel })
+                  }
+                />
               </SelectTrigger>
               <SelectContent className="rounded-xl max-h-60">
                 {managers.length === 0 ? (

--- a/Frontend/src/i18n/en.json
+++ b/Frontend/src/i18n/en.json
@@ -917,6 +917,8 @@
   "emp_no_managers_for_role": "No users found for this role.",
   "emp_select_role_first": "Select a role first",
   "emp_select_manager": "Select a manager",
+  "emp_select_role_value": "Select a {{role}}",
+  "emp_assign_role_value": "Assign {{role}}",
   "emp_manager": "Manager",
   "emp_shift_assigned_success": "Shift assigned successfully.",
   "emp_shift_assign_failed": "Failed to assign shift.",


### PR DESCRIPTION
Closes #218

## Summary
- The "Assign Manager" dialog exposes every non-system role (Team Lead, HR, custom roles, …) but the second field still read "Manager" / "Select a manager" regardless of which role the admin picked.
- `AssignManagerDialog` now derives `selectedRoleLabel` from the same `allRoles` list that populates the role dropdown and uses it for the dialog title, the field label, and the select placeholder.
- Added two interpolated i18n keys (`emp_assign_role_value`, `emp_select_role_value`) to `en.json`. Other locales fall back to English via the existing `fallbackLng: "en"` config.
- The trigger button still reads "Assign Manager" — it remains the umbrella entry point, and the role isn't known until the dialog opens.

## Test plan
- [ ] Select one or more employees on the Employee Details page and click "Assign Manager".
- [ ] With no role chosen, confirm the dialog title reads "Assign Manager", the second field is disabled, and the placeholder reads "Select a role first".
- [ ] Pick "Team Lead" and confirm the dialog title becomes "Assign Team Lead", the field label becomes "Team Lead", and the placeholder becomes "Select a Team Lead".
- [ ] Repeat for "HR" and any custom role; confirm all three strings follow the selected role name.
- [ ] Switch to a non-English locale and confirm the strings fall back to English without rendering raw keys