### PR TITLE
fix(dashboard): correct usage-card dates + widget empty states

### DIFF
--- a/Frontend/src/components/common/ApplicationUsage.jsx
+++ b/Frontend/src/components/common/ApplicationUsage.jsx
@@ -4,6 +4,7 @@ import * as am5 from "@amcharts/amcharts5";
 import * as am5percent from "@amcharts/amcharts5/percent";
 import am5themes_Animated from "@amcharts/amcharts5/themes/Animated";
 import CustomTab from "../../components/common/elements/CustomTab";
+import { getUsagePeriodLabel } from "@/lib/dateTimeUtils";
 
 const fallbackData = {
   today: [
@@ -33,7 +34,7 @@ export default function AppUsageChart({
   activeTab: activeTabProp,
   onTabChange,
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const resolvedTitle = title || t("topTenAppUsage");
   const chartRef = useRef(null);
   const rootRef = useRef(null);
@@ -159,7 +160,7 @@ export default function AppUsageChart({
           <div className="flex items-center gap-2 mt-1">
             <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
             <p className="text-xs font-medium text-slate-400">
-              {t("fromDateRange")}
+              {getUsagePeriodLabel(activeTab, i18n.language)}
             </p>
           </div>
         </div>

--- a/Frontend/src/components/common/Department.jsx
+++ b/Frontend/src/components/common/Department.jsx
@@ -122,6 +122,7 @@ export default function DepartmentPerformance({
 
         {/* List */}
         <div className="flex-1 w-full">
+          {rows.length > 0 && (
           <div className="flex items-center justify-between px-1 mb-2">
             <span className="text-slate-500 text-xs font-medium">
               {t("department")}
@@ -130,6 +131,7 @@ export default function DepartmentPerformance({
               {t("timeHoursLabel")}
             </span>
           </div>
+          )}
           {loading ? (
             <div className="text-center py-8 text-slate-400 text-sm">
               {t("loadingText")}

--- a/Frontend/src/components/common/Location.jsx
+++ b/Frontend/src/components/common/Location.jsx
@@ -237,7 +237,8 @@ export default function LocationPerformance({
 
             {/* List */}
             <div className="flex-1 w-full min-w-0">
-              {/* Column headers */}
+              {/* Column headers — only when there is data */}
+              {rows.length > 0 && (
               <div className="grid grid-cols-[1fr_auto] items-center gap-3 px-1 mb-2">
                 <span className="text-slate-500 text-xs font-medium truncate">
                   {t("location")}
@@ -246,6 +247,7 @@ export default function LocationPerformance({
                   {t("timePercentage")}
                 </span>
               </div>
+              )}
 
               {loading ? (
                 <div className="text-center py-8 text-slate-400 text-sm">

--- a/Frontend/src/components/common/Productive.jsx
+++ b/Frontend/src/components/common/Productive.jsx
@@ -78,7 +78,19 @@ export default function TopProductiveEmployees({
 
         <div className="shrink-0">{filter}</div>
 
+        {/* ── Loading / Empty states ── */}
+        {loading ? (
+          <div className="py-6 text-center text-sm text-slate-500">
+            {t("loadingText")}
+          </div>
+        ) : !employees?.length ? (
+          <div className="py-6 text-center text-sm text-slate-500">
+            {t("noEmployeesForFilters")}
+          </div>
+        ) : null}
+
         {/* ── Table ── */}
+        {employees?.length > 0 && (
         <div className="flex-1 min-h-0 overflow-y-auto">
         <Table>
           <TableHeader>
@@ -95,19 +107,7 @@ export default function TopProductiveEmployees({
           </TableHeader>
 
           <TableBody>
-            {loading ? (
-              <TableRow className="border-b border-dashed border-slate-200 hover:bg-slate-50/60 transition-colors">
-                <TableCell colSpan={resolvedColumns.length} className="py-6 text-slate-500 text-sm">
-                  {t("loadingText")}
-                </TableCell>
-              </TableRow>
-            ) : !employees?.length ? (
-              <TableRow className="border-b border-dashed border-slate-200 hover:bg-slate-50/60 transition-colors">
-                <TableCell colSpan={resolvedColumns.length} className="py-6 text-slate-500 text-sm">
-                  {t("noEmployeesForFilters")}
-                </TableCell>
-              </TableRow>
-            ) : employees.map((emp, idx) => (
+            {employees.map((emp, idx) => (
               <TableRow
                 key={emp?.id ?? emp?.employee_id ?? `${emp?.name ?? "emp"}-${idx}`}
                 className="border-b border-dashed border-slate-200 hover:bg-slate-50/60 transition-colors"
@@ -167,6 +167,7 @@ export default function TopProductiveEmployees({
           </TableBody>
         </Table>
         </div>
+        )}
       </div>
     </>
   );

--- a/Frontend/src/components/common/WebUsage.jsx
+++ b/Frontend/src/components/common/WebUsage.jsx
@@ -4,6 +4,7 @@ import * as am5 from "@amcharts/amcharts5";
 import * as am5percent from "@amcharts/amcharts5/percent";
 import am5themes_Animated from "@amcharts/amcharts5/themes/Animated";
 import CustomTab from "../../components/common/elements/CustomTab";
+import { getUsagePeriodLabel } from "@/lib/dateTimeUtils";
 
 const fallbackData = {
   today: [
@@ -24,7 +25,7 @@ export default function WebUsageChart({
   activeTab: activeTabProp,
   onTabChange,
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const resolvedTitle = title || t("topTenWebUsage");
   const chartRef = useRef(null);
   const rootRef = useRef(null);
@@ -145,7 +146,7 @@ export default function WebUsageChart({
           <h2 className="text-slate-900 font-semibold text-[1.1rem]">
             {resolvedTitle}
           </h2>
-          <p className="text-xs text-gray-400 mt-0.5">{t("fromDateRange")}</p>
+          <p className="text-xs text-gray-400 mt-0.5">{getUsagePeriodLabel(activeTab, i18n.language)}</p>
         </div>
 
         {report}

--- a/Frontend/src/lib/dateTimeUtils.js
+++ b/Frontend/src/lib/dateTimeUtils.js
@@ -17,6 +17,40 @@ export function fmtDateTime(iso) {
   } catch { return iso; }
 }
 
+// Map app i18n language codes to BCP-47 locale tags for date formatting.
+const USAGE_LOCALE_MAP = {
+  en: "en-GB", fr: "fr-FR", es: "es-ES", pt: "pt-BR", idn: "id-ID", ar: "ar",
+};
+
+/**
+ * Human date label for a usage card's period tab.
+ * @param {"today"|"yesterday"|"thisweek"|"thisWeek"} period
+ * @param {string} lang - current i18n language (e.g. "en", "fr")
+ * Returns e.g. "29 May 2026" or "25 May 2026 – 29 May 2026" (week-to-date).
+ */
+export function getUsagePeriodLabel(period, lang = "en") {
+  const locale = USAGE_LOCALE_MAP[lang] || "en-GB";
+  const opts = { day: "numeric", month: "short", year: "numeric" };
+  const today = new Date();
+  const fmt = (d) => d.toLocaleDateString(locale, opts);
+
+  if (period === "yesterday") {
+    const y = new Date(today);
+    y.setDate(y.getDate() - 1);
+    return fmt(y);
+  }
+  if (period === "thisweek" || period === "thisWeek") {
+    const dow = (today.getDay() + 6) % 7; // 0 = Monday
+    const start = new Date(today);
+    start.setDate(today.getDate() - dow);
+    let end = new Date(start);
+    end.setDate(start.getDate() + 6);
+    if (end > today) end = today; // don't show future dates (week-to-date)
+    return `${fmt(start)} – ${fmt(end)}`;
+  }
+  return fmt(today); // "today" (default)
+}
+
 export function diffHMS(startIso, endIso) {
   try {
     const diff = Math.max(0, Math.round((new Date(endIso) - new Date(startIso)) / 1000));


### PR DESCRIPTION
## Summary
Two unrelated dashboard widget bugs.

### 1. Usage cards showed a hardcoded date
Top 10 **Website Usage** and **Application Usage** cards displayed a static placeholder **"From 1–6 Dec, 2020"** (the `fromDateRange` i18n string) regardless of the selected tab. They now show the real date(s) for the active **Today / Yesterday / This Week** tab — localized via a shared `getUsagePeriodLabel()` helper added to `dateTimeUtils.js` (Today → today's date, Yesterday → yesterday, This Week → week-to-date range, capped at today).

### 2. Empty-state widgets rendered an orphaned header
- **Top 10 Productive Employees** rendered its table column header plus a **left-aligned** "No employees found" message when empty. Restructured so empty/loading shows a single **centered** message with **no header**, and the table (header + rows) renders only when data exists — matching the already-correct **Non Productive / Active / Non Active** widgets.
- **Location** and **Department** performance cards had the same orphaned column header on empty; their headers are now gated on `rows.length > 0`.

## Process / verification
- Identified scope via a parallel audit of all 6 candidate widgets (Productive, NonProductive, ActiveEmp, NonActiveEmp, Location, Department) — only the 3 above were inconsistent.
- Each fix adversarially verified (header hidden when empty, message centered, data path intact, JSX balanced) — all pass.
- All changed components HMR-compiled cleanly.

## Test plan
- [ ] Dashboard → Top 10 Website/Application Usage: date label matches the selected Today/Yesterday/This Week tab (try another locale e.g. FR/AR).
- [ ] Top 10 Productive Employees with no data: centered message, no table header.
- [ ] Location & Department cards with no data: no orphaned column header.
- [ ] All widgets still render correctly when data is present.