### PR TITLE
fix(timesheets): align filter row layout & field size with Reports Download

### DIFF
--- a/Frontend/src/components/common/timesheet/TimesheetFilters.jsx
+++ b/Frontend/src/components/common/timesheet/TimesheetFilters.jsx
@@ -23,7 +23,7 @@ function TimesheetFilters({
 }) {
     const { t } = useTranslation();
     return (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5 gap-x-6 gap-y-4 mb-9">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-x-6 gap-y-4 mb-5">
             <div>
                 <label className="block text-sm font-medium text-slate-700 mb-1.5">
                     {t("location")}
@@ -33,6 +33,7 @@ function TimesheetFilters({
                     items={locations}
                     selected={locationValue}
                     onChange={onLocationChange}
+                    width="full"
                 />
             </div>
             <div>
@@ -44,6 +45,7 @@ function TimesheetFilters({
                     items={departments}
                     selected={departmentValue}
                     onChange={onDepartmentChange}
+                    width="full"
                 />
             </div>
             <div>
@@ -55,6 +57,7 @@ function TimesheetFilters({
                     items={employees}
                     selected={employeeValue}
                     onChange={onEmployeeChange}
+                    width="full"
                 />
             </div>
             <div>
@@ -66,6 +69,7 @@ function TimesheetFilters({
                     items={shifts}
                     selected={shiftValue}
                     onChange={onShiftChange}
+                    width="full"
                 />
             </div>
             <div>


### PR DESCRIPTION
## Summary
The Timesheets filter row (Location / Department / Employee / Shift / Date Range) looked sparse and inconsistent with the Reports Download page:
- the 5-column grid only activated at `2xl` (1536px), so on mid-wide screens it wrapped to 3 columns with uneven gaps;
- the `CustomSelect` dropdowns rendered at their default (narrow) width and didn't fill their grid columns.

This aligns the row with the Reports Download page exactly:
- grid columns now activate at `xl` (1280px) instead of `2xl`;
- each `CustomSelect` passes `width="full"` so it fills its column;
- bottom margin `mb-9` -> `mb-5`.

Result: the five filters sit evenly across the row at a consistent size, matching the Reports Download layout.

## Test plan
- [ ] /admin/timesheets: filter fields span their columns evenly (same look/size as /admin/reports/download).
- [ ] Resize the window — 5-across from ~xl, wraps gracefully below, full-width stacked on mobile.
- [ ] Each dropdown still opens and filters correctly; the date-range picker still works.