### PR TITLE
fix: EMP Cloud back button redirects to dashboard, not marketing login

### DIFF
--- a/Frontend/src/components/BackToCloud.jsx
+++ b/Frontend/src/components/BackToCloud.jsx
@@ -1,16 +1,29 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
+
+const EMPCLOUD_DASHBOARD_URL = 'https://app.empcloud.com/';
+
+/**
+ * Resolve the "EMP Cloud" return URL from localStorage (set by SSOGate).
+ * Older sessions may hold a stale value pointing at the bare empcloud.com
+ * marketing site (WordPress wp-login), produced before the SSO return_url fix —
+ * redirect those to the real dashboard. Subdomains like app.empcloud.com are
+ * kept as-is. Returns null when the user did not arrive via SSO.
+ */
+function resolveReturnUrl() {
+  const stored = localStorage.getItem('empcloud_return_url');
+  if (!stored) return null;
+  let host = '';
+  try { host = new URL(stored).hostname; } catch { host = ''; }
+  const isMarketingSite = /^(www\.)?empcloud\.com$/i.test(host);
+  return isMarketingSite || !host ? EMPCLOUD_DASHBOARD_URL : stored;
+}
 
 /**
  * Subtle "EMP Cloud" link shown only when the user arrived via SSO.
- * Reads empcloud_return_url from localStorage (set by SSOGate).
  */
 export default function BackToCloud() {
-  const [returnUrl, setReturnUrl] = useState(null);
-
-  useEffect(() => {
-    setReturnUrl(localStorage.getItem('empcloud_return_url'));
-  }, []);
+  const [returnUrl] = useState(resolveReturnUrl);
 
   if (!returnUrl) return null;
 

--- a/Frontend/src/components/SSOGate.jsx
+++ b/Frontend/src/components/SSOGate.jsx
@@ -30,10 +30,7 @@ export default function SSOGate({ children }) {
   const navigate = useNavigate();
 
   // Extract once on mount — never re-run (token already stripped from URL)
-  const [ssoToken] = useState(() => {
-    const token = extractSSOToken();
-    return token;
-  });
+  const [{ token: ssoToken, returnUrl: ssoReturnUrl }] = useState(() => extractSSOToken());
   const [ready, setReady] = useState(!ssoToken); // if no SSO token, render immediately
   const [error, setError] = useState(null);
 
@@ -108,16 +105,16 @@ export default function SSOGate({ children }) {
         // Also set the bare token (used by some API interceptors)
         localStorage.setItem('token', accessToken);
 
-        // Remember where to return to in EMP Cloud.
-        // For empmonitor.empcloud.com → empcloud.com (strip the empmonitor subdomain).
-        // For other hosts (localhost, custom domains) leave unchanged.
-        const host = window.location.host;
-        const empCloudHost = /^empmonitor\./i.test(host)
-          ? host.replace(/^empmonitor\./i, '')
-          : host;
+        // Remember where to return to in EMP Cloud for the "EMP Cloud" back
+        // link. Use the return_url EmpCloud passed in the SSO query string —
+        // it points at the real dashboard. Do NOT reconstruct it by stripping
+        // the host: empmonitor.empcloud.com → empcloud.com lands on the
+        // WordPress marketing site (wp-login), not the dashboard. Mirror the
+        // proven emp-payroll SSO behavior.
+        localStorage.setItem('sso_source', 'empcloud');
         localStorage.setItem(
           'empcloud_return_url',
-          `${window.location.protocol}//${empCloudHost}/dashboard`,
+          ssoReturnUrl || 'https://app.empcloud.com/',
         );
 
         // Navigate based on role. Use a full-page reload (not React
@@ -149,7 +146,7 @@ export default function SSOGate({ children }) {
     return () => {
       cancelled = true;
     };
-  }, [ssoToken, login, navigate, setAdmin, setNonAdmin, setEmployee]);
+  }, [ssoToken, ssoReturnUrl, login, navigate, setAdmin, setNonAdmin, setEmployee]);
 
   if (!ready) {
     return (

--- a/Frontend/src/lib/auth-store.js
+++ b/Frontend/src/lib/auth-store.js
@@ -1,19 +1,27 @@
 import { create } from 'zustand';
 
 /**
- * Extracts the ?sso_token= param from the current URL and immediately
- * removes it so the token never lingers in browser history.
+ * Extracts the ?sso_token= and ?return_url= params from the current URL and
+ * immediately removes them so the token never lingers in browser history.
+ *
+ * Returns { token, returnUrl }. returnUrl is the EMP Cloud dashboard URL that
+ * EmpCloud passes alongside the token — it must be used as-is for the "EMP
+ * Cloud" back link (do NOT reconstruct it from the host; empcloud.com is the
+ * WordPress marketing site, not the dashboard).
  */
 export function extractSSOToken() {
   const params = new URLSearchParams(window.location.search);
   const ssoToken = params.get('sso_token');
-  if (!ssoToken) return null;
+  if (!ssoToken) return { token: null, returnUrl: null };
+
+  const returnUrl = params.get('return_url');
 
   const url = new URL(window.location.href);
   url.searchParams.delete('sso_token');
+  url.searchParams.delete('return_url');
   window.history.replaceState({}, '', url.pathname + url.search + url.hash);
 
-  return ssoToken;
+  return { token: ssoToken, returnUrl };
 }
 
 const STORAGE_KEY = 'empmonitor_auth';


### PR DESCRIPTION
## Summary

The "EMP Cloud" back button in the navbar redirected to the WordPress marketing site login (`empcloud.com/wp-login.php`) instead of the EmpCloud dashboard.

## Root cause

`SSOGate` built the return URL by stripping `empmonitor.` from the host:

```
empmonitor.empcloud.com -> empcloud.com/dashboard
```

`empcloud.com` is the WordPress marketing site, which has no `/dashboard`, so it bounced the user to `wp-login.php?redirect_to=...&reauth=1`.

The EMP Payroll module does **not** have this problem because its SSO reads the `return_url` query param that EmpCloud sends and stores it as-is, rather than reconstructing the host.

## Fix

Mirror the proven emp-payroll SSO behavior:

- `extractSSOToken()` now also reads (and strips) the `return_url` query param, returning `{ token, returnUrl }`.
- `SSOGate` stores that real `return_url` into `empcloud_return_url` (and sets `sso_source`), falling back to `https://app.empcloud.com/` when none is supplied. Removed the host-stripping logic.
- `BackToCloud` sanitizes stale cached values: any URL pointing at the bare `empcloud.com` / `www.empcloud.com` marketing host (left over from before this fix) is redirected to `https://app.empcloud.com/`. Subdomains like `app.empcloud.com` are kept as-is.

## Verification

- ESLint passes clean on all three changed files.
- Fresh SSO with `return_url` -> returns there. Without it -> `https://app.empcloud.com/`. Stale `empcloud.com` cache -> corrected to `https://app.empcloud.com/`.

Frontend-only change.

Fixes #225