### PR TITLE
feat: real data-driven insight cards in dashboard EMP AI panel

### DIFF
--- a/Frontend/src/components/common/EmpAi.jsx
+++ b/Frontend/src/components/common/EmpAi.jsx
@@ -1,74 +1,78 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  Instagram,
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  Users,
   Usb,
-  MonitorPlay,
-  Settings,
+  Info,
+  Sparkles,
 } from "lucide-react";
 import empaiLogo from "@/assets/empai.png";
+import { useDashboardStore } from "@/page/protected/admin/dashboard/dashboardStore";
+import { buildInsightCards } from "./empAiInsights";
 import "./EmpAi.css";
 
-const CARDS = [
-  {
-    id: 1,
-    name: "Andrei Luca",
-    desc: '"Lorem ipsum quia dolor sit porro quisquam est qui amet consectetur adipisci"',
-    Icon: Instagram,
-    palette: {
-      bg: "bg-[#E6FBF7]",
-      bar: "bg-[#00CC9A]",
-      text: "text-[#00CC9A]",
-      iconBg: "bg-[#00CC9A]",
-      divider: "bg-[#00CC9A]/30",
-    },
-  },
-  {
-    id: 2,
-    name: "Andrei Luca",
-    desc: '"Lorem ipsum quia dolor sit porro quisquam est qui amet consectetur adipisci"',
-    Icon: Usb,
-    palette: {
-      bg: "bg-[#FFEEEF]",
-      bar: "bg-[#EB5958]",
-      text: "text-[#EB5958]",
-      iconBg: "bg-[#EB5958]",
-      divider: "bg-[#EB5958]/30",
-    },
-  },
-  {
-    id: 3,
-    name: "Andrei Luca",
-    desc: '"Lorem ipsum quia dolor sit porro quisquam est qui amet consectetur adipisci"',
-    Icon: MonitorPlay,
-    palette: {
-      bg: "bg-[#FEF8E8]",
-      bar: "bg-[#F2C84F]",
-      text: "text-[#F2C84F]",
-      iconBg: "bg-[#F2C84F]",
-      divider: "bg-[#F2C84F]/30",
-    },
-  },
-  {
-    id: 4,
-    name: "Andrei Luca",
-    desc: '"Lorem ipsum quia dolor sit porro quisquam est qui amet consectetur adipisci"',
-    Icon: Settings,
-    palette: {
-      bg: "bg-[#ECEDFE]",
-      bar: "bg-[#5458F4]",
-      text: "text-[#5458F4]",
-      iconBg: "bg-[#5458F4]",
-      divider: "bg-[#5458F4]/30",
-    },
-  },
-];
+// EmpAi is rendered on both the admin and non-admin dashboards, which use
+// separate Zustand stores with the same shape. Each dashboard injects its own
+// store hook via the `useStore` prop; the admin store is the default so the
+// existing `<EmpAi />` call sites keep working unchanged.
+
+// Map an insight "tone" to the existing card colour palette so the visual
+// design is unchanged from the original mockup.
+const PALETTES = {
+  good: { bg: "bg-[#E6FBF7]", bar: "bg-[#00CC9A]", text: "text-[#00CC9A]", iconBg: "bg-[#00CC9A]", divider: "bg-[#00CC9A]/30" },
+  bad: { bg: "bg-[#FFEEEF]", bar: "bg-[#EB5958]", text: "text-[#EB5958]", iconBg: "bg-[#EB5958]", divider: "bg-[#EB5958]/30" },
+  warn: { bg: "bg-[#FEF8E8]", bar: "bg-[#F2C84F]", text: "text-[#F2C84F]", iconBg: "bg-[#F2C84F]", divider: "bg-[#F2C84F]/30" },
+  info: { bg: "bg-[#ECEDFE]", bar: "bg-[#5458F4]", text: "text-[#5458F4]", iconBg: "bg-[#5458F4]", divider: "bg-[#5458F4]/30" },
+};
+
+const ICONS = {
+  "trend-up": TrendingUp,
+  "trend-down": TrendingDown,
+  alert: AlertTriangle,
+  users: Users,
+  usb: Usb,
+  info: Info,
+};
 
 const MORPH_MS = 320;
 
-const EmpAi = () => {
+const EmpAi = ({ useStore = useDashboardStore, onOpenInsight }) => {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
+
+  // Pull the slices the insight engine needs. Subscribing to each slice keeps
+  // re-renders tight and avoids recomputing on unrelated store changes.
+  const statsLists = useStore((s) => s.statsLists);
+  const activityBreakdown = useStore((s) => s.activityBreakdown);
+  const productiveEmployees = useStore((s) => s.productiveEmployees);
+  const unproductiveEmployees = useStore((s) => s.unproductiveEmployees);
+  const nonActiveEmployees = useStore((s) => s.nonActiveEmployees);
+  const activeEmployees = useStore((s) => s.activeEmployees);
+  const locationPerformance = useStore((s) => s.locationPerformance);
+  const departmentPerformance = useStore((s) => s.departmentPerformance);
+  const webUsage = useStore((s) => s.webUsage);
+  const appUsage = useStore((s) => s.appUsage);
+  const loading = useStore((s) => s.loading);
+
+  const cards = useMemo(
+    () =>
+      buildInsightCards({
+        statsLists,
+        activityBreakdown,
+        productiveEmployees,
+        unproductiveEmployees,
+        nonActiveEmployees,
+        activeEmployees,
+        locationPerformance,
+        departmentPerformance,
+        webUsage,
+        appUsage,
+      }, 12),
+    [statsLists, activityBreakdown, productiveEmployees, unproductiveEmployees, nonActiveEmployees, activeEmployees, locationPerformance, departmentPerformance, webUsage, appUsage],
+  );
 
   return (
     <div className="h-full">
@@ -124,39 +128,73 @@ const EmpAi = () => {
           </p>
         </div>
 
-        {/* Cards — mounted only when expanded; each notifies-in with stagger */}
+        {/* Insight cards — mounted only when expanded; each notifies-in with stagger */}
         {expanded && (
           <div className="absolute inset-x-0 bottom-0 top-22 overflow-y-auto overflow-x-hidden px-3 pt-2 pb-3 space-y-3">
-            {CARDS.map((card, idx) => {
-              const { Icon, palette } = card;
-              return (
-                <div
-                  key={card.id}
-                  style={{ animationDelay: `${MORPH_MS - 120 + idx * 60}ms` }}
-                  className={`${palette.bg} empai-card empai-notif-in rounded-[6px] flex items-stretch overflow-`}
-                >
-                  <div className={`min-w-1.5 my-[1px] ${palette.bar} rounded-full`} />
-                  <div className="flex-1 min-w-0 flex items-center gap-3 p-3">
-                    <div className="flex-1 min-w-0">
-                      <h3 className={`text-sm font-semibold ${palette.text} truncate`}>
-                        {card.name}
-                      </h3>
-                      <p className="text-[11px] leading-snug text-slate-600 mt-1 line-clamp-2">
-                        {card.desc}
-                      </p>
-                    </div>
-                    <div className={`w-px self-stretch ${palette.divider}`} />
-                    <div
-                      className={`${palette.iconBg} relative shrink-0 w-11 h-11 rounded-lg
-                                  flex items-center justify-center text-white shadow-sm`}
-                    >
-                      <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-white/40" />
-                      <Icon className="size-5" strokeWidth={2} />
+            {cards.length === 0 ? (
+              <div className="h-full flex flex-col items-center justify-center text-center px-4 py-8">
+                <div className="w-10 h-10 rounded-full bg-sky-50 flex items-center justify-center mb-3">
+                  <Sparkles className="size-5 text-sky-400" />
+                </div>
+                <p className="text-sm font-medium text-slate-600">
+                  {loading ? "Analyzing today's activity…" : "No insights yet"}
+                </p>
+                <p className="text-[11px] text-slate-400 mt-1 max-w-[200px]">
+                  {loading
+                    ? "Hang tight while EMP AI reviews your team's data."
+                    : "Insights appear here once there's enough activity data for today."}
+                </p>
+              </div>
+            ) : (
+              cards.map((card, idx) => {
+                const palette = PALETTES[card.tone] ?? PALETTES.info;
+                const Icon = ICONS[card.icon] ?? Info;
+                const clickable = Boolean(card.modal && onOpenInsight);
+                const open = () => onOpenInsight?.(card);
+                return (
+                  <div
+                    key={card.id}
+                    onClick={clickable ? open : undefined}
+                    role={clickable ? "button" : undefined}
+                    tabIndex={clickable ? 0 : undefined}
+                    onKeyDown={
+                      clickable
+                        ? (e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              open();
+                            }
+                          }
+                        : undefined
+                    }
+                    style={{ animationDelay: `${MORPH_MS - 120 + idx * 60}ms` }}
+                    className={`${palette.bg} empai-card empai-notif-in rounded-[6px] flex items-stretch overflow-hidden ${
+                      clickable ? "cursor-pointer hover:brightness-[0.98] transition" : ""
+                    }`}
+                  >
+                    <div className={`min-w-1.5 my-[1px] ${palette.bar} rounded-full`} />
+                    <div className="flex-1 min-w-0 flex items-center gap-3 p-3">
+                      <div className="flex-1 min-w-0">
+                        <h3 className={`text-sm font-semibold ${palette.text}`}>
+                          {card.title}
+                        </h3>
+                        <p className="text-[11px] leading-snug text-slate-600 mt-1 line-clamp-2">
+                          {card.desc}
+                        </p>
+                      </div>
+                      <div className={`w-px self-stretch ${palette.divider}`} />
+                      <div
+                        className={`${palette.iconBg} relative shrink-0 w-11 h-11 rounded-lg
+                                    flex items-center justify-center text-white shadow-sm`}
+                      >
+                        <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-white/40" />
+                        <Icon className="size-5" strokeWidth={2} />
+                      </div>
                     </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              })
+            )}
           </div>
         )}
       </div>

--- a/Frontend/src/components/common/elements/ViewReportModal.jsx
+++ b/Frontend/src/components/common/elements/ViewReportModal.jsx
@@ -79,6 +79,15 @@ const COLUMNS = {
     col("name", "Name"),
     col("value", "Usage %", { className: "text-blue-500 font-semibold", isPercent: true }),
   ],
+  // Plain roster list — for absent/suspended/offline/enrolled employees who
+  // have no activity to fetch. Renders the bucket rows directly via staticData.
+  employee_list: [
+    col("name", "Employee"),
+    col("emp_code", "Emp Code", { aliases: ["empCode"] }),
+    col("email", "Email", { aliases: ["a_email"] }),
+    col("location", "Location", { aliases: ["location_name"] }),
+    col("department", "Department", { aliases: ["department_name"] }),
+  ],
 };
 
 // Name has multiple possible source fields

--- a/Frontend/src/components/common/empAiInsights.js
+++ b/Frontend/src/components/common/empAiInsights.js
@@ -1,0 +1,417 @@
+/**
+ * EMP AI — dashboard insight engine.
+ *
+ * Pure, side-effect-free derivation of "insight cards" from the data the
+ * dashboard store has already loaded (no extra API calls). Each card surfaces a
+ * real, actionable signal — idle spikes, absences, top/bottom performers,
+ * productivity trends — and deep-links to the relevant screen.
+ *
+ * This replaces the previous hardcoded "Andrei Luca / Lorem ipsum" mockup in
+ * EmpAi.jsx. Every number here comes from live dashboard data; if the data
+ * isn't loaded yet the engine returns an empty list and the UI shows a
+ * friendly empty state.
+ *
+ * Card shape:
+ *   {
+ *     id:       stable string key (for React + de-dupe)
+ *     tone:     "good" | "warn" | "bad" | "info"  → drives the colour palette
+ *     icon:     one of "trend-up" | "trend-down" | "alert" | "users" | "usb" | "info"
+ *     title:    short headline (already localized by caller where needed)
+ *     desc:     one-line detail
+ *     to:       optional in-app route to deep-link to on click
+ *   }
+ */
+
+/** Parse "HH:MM:SS" or a raw seconds number into seconds. Returns 0 on junk. */
+function toSeconds(value) {
+  if (value == null) return 0;
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  const str = String(value).trim();
+  if (/^\d+$/.test(str)) return parseInt(str, 10);
+  // "HH:MM:SS (12%)" → take the time part before any parenthesis
+  const timePart = str.split("(")[0].trim();
+  const m = timePart.match(/^(\d+):(\d{2}):(\d{2})$/);
+  if (!m) return 0;
+  return parseInt(m[1], 10) * 3600 + parseInt(m[2], 10) * 60 + parseInt(m[3], 10);
+}
+
+/** Pull the leading "NN%" out of a "HH:MM:SS (NN%)" cell, else null. */
+function toPercent(value) {
+  if (value == null) return null;
+  const m = String(value).match(/\(?\s*(\d+(?:\.\d+)?)\s*%/);
+  return m ? parseFloat(m[1]) : null;
+}
+
+/** Human label for an employee record across the various API shapes. */
+function employeeName(emp) {
+  if (!emp) return "An employee";
+  const first = emp.first_name ?? emp.firstName ?? "";
+  const last = emp.last_name ?? emp.lastName ?? "";
+  const full = `${first} ${last}`.trim();
+  return full || emp.name || emp.full_name || emp.employee_name || emp.emp_code || "An employee";
+}
+
+const fmtHrs = (sec) => {
+  const h = sec / 3600;
+  if (h >= 1) return `${h.toFixed(1)} hrs`;
+  const m = Math.round(sec / 60);
+  return `${m} min`;
+};
+
+/**
+ * Modal descriptors. Each card carries a `modal` instead of a route — clicking
+ * opens ViewReportModal in-place on the dashboard rather than navigating away.
+ *   - dataset: which store slice to show (resolved by the host component)
+ *   - mode:    ViewReportModal mode ("employee_activity" | "timesheet" | "web_app")
+ *   - title:   modal heading
+ */
+const MODAL = {
+  // Roster buckets → employee_list (renders the list directly; absent/offline
+  // employees have no activity to fetch, so employee_activity returns empty).
+  absent: { dataset: "absentEmp", mode: "employee_list", title: "Absent Employees Today" },
+  idle: { dataset: "idleEmps", mode: "employee_list", title: "Idle Employees" },
+  offline: { dataset: "offlineEmp", mode: "employee_list", title: "Offline Employees" },
+  online: { dataset: "onlineEmps", mode: "employee_list", title: "Online Employees" },
+  registered: { dataset: "registeredEmp", mode: "employee_list", title: "All Enrolled Employees" },
+  suspended: { dataset: "suspendedEmp", mode: "employee_list", title: "Suspended Accounts" },
+  // Performer lists already carry activity columns → employee_activity fetch.
+  productive: { dataset: "productiveEmployees", mode: "employee_activity", title: "Top 10 Productive Employees" },
+  unproductive: { dataset: "unproductiveEmployees", mode: "employee_activity", title: "Top 10 Non-Productive Employees" },
+  active: { dataset: "activeEmployees", mode: "timesheet", title: "Top 10 Active Employees" },
+  nonActive: { dataset: "nonActiveEmployees", mode: "timesheet", title: "Least Active Employees" },
+  web: { dataset: "webUsage", mode: "web_app", title: "Top Website Usage" },
+  app: { dataset: "appUsage", mode: "web_app", title: "Top Application Usage" },
+  locationPerf: { dataset: "locationPerformance", mode: "performance", title: "Location Performance" },
+  departmentPerf: { dataset: "departmentPerformance", mode: "performance", title: "Department Performance" },
+};
+
+/** First non-empty top item ({name, value}) from a web/app usage slice. */
+function topUsageItem(usage) {
+  if (!usage) return null;
+  const list = Array.isArray(usage) ? usage : usage.today;
+  if (!Array.isArray(list) || list.length === 0) return null;
+  return list[0];
+}
+
+/**
+ * Build the insight cards from the dashboard store snapshot.
+ *
+ * @param {object} store  values from useDashboardStore (statsLists,
+ *                        activityBreakdown, productiveEmployees,
+ *                        unproductiveEmployees, nonActiveEmployees, ...)
+ * @param {number} limit  max cards to return (panel shows a handful)
+ * @returns {Array} insight cards, highest-priority first
+ */
+export function buildInsightCards(store = {}, limit = 6) {
+  const {
+    statsLists = {},
+    activityBreakdown = [],
+    productiveEmployees = [],
+    unproductiveEmployees = [],
+    nonActiveEmployees = [],
+    activeEmployees = [],
+    locationPerformance = { rows: [] },
+    departmentPerformance = { rows: [] },
+    webUsage = [],
+    appUsage = [],
+  } = store;
+
+  const cards = [];
+
+  // ── Roster signals (from /dashboard/employees buckets) ──
+  const idle = statsLists.idleEmps?.length ?? 0;
+  const offline = statsLists.offlineEmp?.length ?? 0;
+  const absent = statsLists.absentEmp?.length ?? 0;
+  const online = statsLists.onlineEmps?.length ?? 0;
+  const registered = statsLists.registeredEmp?.length ?? 0;
+  const suspended = statsLists.suspendedEmp?.length ?? 0;
+  const present = Math.max(registered - absent, 0);
+
+  if (absent > 0) {
+    cards.push({
+      id: "absent",
+      priority: 90,
+      tone: "bad",
+      icon: "alert",
+      title: `${absent} ${absent === 1 ? "employee" : "employees"} absent today`,
+      desc: "No activity recorded yet — check leave records or follow up.",
+      modal: MODAL.absent,
+    });
+  }
+
+  if (idle > 0) {
+    cards.push({
+      id: "idle",
+      priority: 70,
+      tone: "warn",
+      icon: "alert",
+      title: `${idle} ${idle === 1 ? "employee is" : "employees are"} idle right now`,
+      desc: "Sustained inactivity on an active session — worth a check-in.",
+      modal: MODAL.idle,
+    });
+  }
+
+  if (offline > 0 && registered > 0) {
+    const pct = Math.round((offline / registered) * 100);
+    cards.push({
+      id: "offline",
+      priority: 50,
+      tone: "info",
+      icon: "users",
+      title: `${offline} offline (${pct}% of team)`,
+      desc: online > 0 ? `${online} currently online.` : "No one is currently online.",
+      modal: MODAL.offline,
+    });
+  }
+
+  // ── Currently active / online ──
+  if (online > 0) {
+    cards.push({
+      id: "online",
+      priority: 42,
+      tone: "good",
+      icon: "users",
+      title: `${online} ${online === 1 ? "employee" : "employees"} active right now`,
+      desc: idle > 0 ? `${idle} idle, the rest are working.` : "Currently online and working.",
+      modal: MODAL.online,
+    });
+  }
+
+  // ── Attendance rate (always computable when there's a roster) ──
+  if (registered > 0) {
+    const rate = Math.round((present / registered) * 100);
+    cards.push({
+      id: "attendance",
+      priority: absent > 0 ? 60 : 35,
+      tone: rate >= 90 ? "good" : rate >= 70 ? "warn" : "bad",
+      icon: rate >= 90 ? "trend-up" : "alert",
+      title: `Attendance ${rate}% today`,
+      desc: `${present} of ${registered} ${registered === 1 ? "employee" : "employees"} present.`,
+      modal: MODAL.registered,
+    });
+  }
+
+  // ── Suspended accounts ──
+  if (suspended > 0) {
+    cards.push({
+      id: "suspended",
+      priority: 38,
+      tone: "info",
+      icon: "alert",
+      title: `${suspended} suspended ${suspended === 1 ? "account" : "accounts"}`,
+      desc: "Review suspended users — reactivate or remove as needed.",
+      modal: MODAL.suspended,
+    });
+  }
+
+  // ── Team size / enrollment summary (always useful baseline) ──
+  if (registered > 0) {
+    cards.push({
+      id: "team-size",
+      priority: 20,
+      tone: "info",
+      icon: "users",
+      title: `${registered} ${registered === 1 ? "employee" : "employees"} enrolled`,
+      desc: online > 0 ? `${online} active right now.` : "Monitoring your full workforce.",
+      modal: MODAL.registered,
+    });
+  }
+
+  // ── "All clear" positive state — nobody idle/offline/absent ──
+  if (registered > 0 && absent === 0 && idle === 0 && offline === 0) {
+    cards.push({
+      id: "all-clear",
+      priority: 25,
+      tone: "good",
+      icon: "trend-up",
+      title: "All systems quiet",
+      desc: "No absences, idle, or offline employees right now. Nice and steady.",
+      // No modal — this is a positive status card with no underlying list.
+    });
+  }
+
+  // ── Productivity trend (today vs yesterday, from activity breakdown) ──
+  const prodRow = activityBreakdown.find((r) => r.activity === "Productive Hours");
+  if (prodRow) {
+    const todayPct = toPercent(prodRow.today);
+    const yestPct = toPercent(prodRow.yesterday);
+    if (todayPct != null && yestPct != null) {
+      const delta = Math.round(todayPct - yestPct);
+      if (Math.abs(delta) >= 5) {
+        const up = delta > 0;
+        cards.push({
+          id: "prod-trend",
+          priority: up ? 40 : 75,
+          tone: up ? "good" : "warn",
+          icon: up ? "trend-up" : "trend-down",
+          title: `Productivity ${up ? "up" : "down"} ${Math.abs(delta)}% vs yesterday`,
+          desc: `Now at ${todayPct}% productive time across the team.`,
+          modal: up ? MODAL.productive : MODAL.unproductive,
+        });
+      }
+    }
+  }
+
+  // ── Idle-time spike (today vs yesterday) ──
+  const idleRow = activityBreakdown.find((r) => r.activity === "Idle Hours");
+  if (idleRow) {
+    const todaySec = toSeconds(idleRow.today);
+    const yestSec = toSeconds(idleRow.yesterday);
+    if (yestSec > 0 && todaySec > yestSec * 1.25) {
+      const jump = Math.round(((todaySec - yestSec) / yestSec) * 100);
+      cards.push({
+        id: "idle-spike",
+        priority: 65,
+        tone: "warn",
+        icon: "trend-down",
+        title: `Idle time up ${jump}% today`,
+        desc: `Team idle time rose to ${fmtHrs(todaySec)} from ${fmtHrs(yestSec)} yesterday.`,
+        modal: MODAL.idle,
+      });
+    }
+  }
+
+  // ── Top performer recognition (named highlight — distinct from the
+  //    "Top 10 Productive" list card below: this calls out the #1 person) ──
+  const topProd = productiveEmployees[0];
+  if (topProd) {
+    cards.push({
+      id: "top-performer",
+      priority: 30,
+      tone: "good",
+      icon: "trend-up",
+      title: `${employeeName(topProd)} is today's top performer`,
+      desc: "Leading the team on productive hours — worth recognizing.",
+      modal: MODAL.productive,
+    });
+  }
+
+  // ── Lowest performer attention (named highlight) ──
+  const lowProd = unproductiveEmployees[0];
+  if (lowProd) {
+    cards.push({
+      id: "low-performer",
+      priority: 55,
+      tone: "warn",
+      icon: "trend-down",
+      title: `${employeeName(lowProd)} needs attention`,
+      desc: "Highest non-productive time today — consider a 1-on-1.",
+      modal: MODAL.unproductive,
+    });
+  }
+
+  // ── Not-logged-in callout ──
+  if (nonActiveEmployees.length > 0) {
+    cards.push({
+      id: "non-active",
+      priority: 45,
+      tone: "info",
+      icon: "users",
+      title: `${nonActiveEmployees.length} ${nonActiveEmployees.length === 1 ? "employee" : "employees"} barely active`,
+      desc: "Low online time today — may be on leave or facing connectivity issues.",
+      modal: MODAL.nonActive,
+    });
+  }
+
+  // ── Top 10 Productive Employees (always available when loaded) ──
+  if (productiveEmployees.length > 0) {
+    cards.push({
+      id: "top10-productive",
+      priority: 28,
+      tone: "good",
+      icon: "trend-up",
+      title: "Top 10 Productive Employees",
+      desc: `${productiveEmployees.length} ${productiveEmployees.length === 1 ? "employee" : "employees"} ranked by productive time. Tap to view.`,
+      modal: MODAL.productive,
+    });
+  }
+
+  // ── Top 10 Non-Productive Employees ──
+  if (unproductiveEmployees.length > 0) {
+    cards.push({
+      id: "top10-nonproductive",
+      priority: 27,
+      tone: "warn",
+      icon: "trend-down",
+      title: "Top 10 Non-Productive Employees",
+      desc: `${unproductiveEmployees.length} ${unproductiveEmployees.length === 1 ? "employee" : "employees"} with the most non-productive time.`,
+      modal: MODAL.unproductive,
+    });
+  }
+
+  // ── Top 10 Active Employees ──
+  if (activeEmployees.length > 0) {
+    cards.push({
+      id: "top10-active",
+      priority: 24,
+      tone: "info",
+      icon: "users",
+      title: "Top 10 Active Employees",
+      desc: `${activeEmployees.length} most active by workstation hours today.`,
+      modal: MODAL.active,
+    });
+  }
+
+  // ── Best-performing location ──
+  const locRows = Array.isArray(locationPerformance?.rows) ? locationPerformance.rows : [];
+  if (locRows.length > 0) {
+    const top = locRows[0];
+    cards.push({
+      id: "loc-perf",
+      priority: 22,
+      tone: "info",
+      icon: "trend-up",
+      title: `Top location: ${top?.name ?? "—"}`,
+      desc: `Leads ${locRows.length} ${locRows.length === 1 ? "location" : "locations"} on performance. Tap for the full breakdown.`,
+      modal: MODAL.locationPerf,
+    });
+  }
+
+  // ── Best-performing department ──
+  const deptRows = Array.isArray(departmentPerformance?.rows) ? departmentPerformance.rows : [];
+  if (deptRows.length > 0) {
+    const top = deptRows[0];
+    cards.push({
+      id: "dept-perf",
+      priority: 21,
+      tone: "info",
+      icon: "trend-up",
+      title: `Top department: ${top?.name ?? "—"}`,
+      desc: `Leads ${deptRows.length} ${deptRows.length === 1 ? "department" : "departments"} on performance. Tap for details.`,
+      modal: MODAL.departmentPerf,
+    });
+  }
+
+  // ── Top website today ──
+  const topWeb = topUsageItem(webUsage);
+  if (topWeb?.name && topWeb.value > 0) {
+    cards.push({
+      id: "top-web",
+      priority: 18,
+      tone: "info",
+      icon: "info",
+      title: `Top website: ${topWeb.name}`,
+      desc: `Accounts for ${Math.round(topWeb.value)}% of web time today.`,
+      modal: MODAL.web,
+    });
+  }
+
+  // ── Top application today ──
+  const topApp = topUsageItem(appUsage);
+  if (topApp?.name && topApp.value > 0) {
+    cards.push({
+      id: "top-app",
+      priority: 16,
+      tone: "info",
+      icon: "info",
+      title: `Top app: ${topApp.name}`,
+      desc: `Most-used application today at ${Math.round(topApp.value)}% of app time.`,
+      modal: MODAL.app,
+    });
+  }
+
+  // Highest-priority first, then cap. (Cards intentionally may share a modal
+  // dataset — e.g. the "top performer" highlight and the "Top 10 Productive"
+  // list — because they convey different insights; they have distinct ids.)
+  return cards.sort((a, b) => b.priority - a.priority).slice(0, limit);
+}

--- a/Frontend/src/page/protected/admin/dashboard/index.jsx
+++ b/Frontend/src/page/protected/admin/dashboard/index.jsx
@@ -66,6 +66,7 @@ const Dashboard = () => {
 
   const {
     stats,
+    statsLists,
     activitySnapshot,
     activityBreakdown,
     webUsage,
@@ -120,6 +121,39 @@ const Dashboard = () => {
       by: opts.by || "today",
     });
   }, []);
+
+  // Open an EMP-AI insight card in the dashboard's ViewReportModal instead of
+  // navigating away. The card's `modal.dataset` names a store slice; resolve it
+  // to the actual rows here. web/app slices store the list under `.today`;
+  // statsLists buckets and the *Employees arrays are already plain lists.
+  const handleOpenInsight = useCallback((card) => {
+    const m = card?.modal;
+    if (!m) return;
+    const SOURCES = {
+      absentEmp: statsLists?.absentEmp,
+      idleEmps: statsLists?.idleEmps,
+      offlineEmp: statsLists?.offlineEmp,
+      onlineEmps: statsLists?.onlineEmps,
+      registeredEmp: statsLists?.registeredEmp,
+      suspendedEmp: statsLists?.suspendedEmp,
+      productiveEmployees,
+      unproductiveEmployees,
+      nonActiveEmployees,
+      activeEmployees,
+      locationPerformance: locationPerformance?.rows,
+      departmentPerformance: departmentPerformance?.rows,
+      webUsage: webUsage?.today,
+      appUsage: appUsage?.today,
+    };
+    const data = Array.isArray(SOURCES[m.dataset]) ? SOURCES[m.dataset] : [];
+    if (m.mode === "employee_activity") {
+      // Activity columns are fetched per-employee from the ids in `employees`.
+      openViewReport(m.title, { mode: "employee_activity", employees: data });
+    } else {
+      // employee_list / timesheet / web_app all render staticData directly.
+      openViewReport(m.title, { mode: m.mode, staticData: data });
+    }
+  }, [statsLists, productiveEmployees, unproductiveEmployees, nonActiveEmployees, activeEmployees, locationPerformance, departmentPerformance, webUsage, appUsage, openViewReport]);
 
   useEffect(() => {
     loadDashboard();
@@ -607,7 +641,7 @@ const Dashboard = () => {
         </div>
 
         <div className="xl:col-span-3 col-span-12">
-          <EmpAi />
+          <EmpAi onOpenInsight={handleOpenInsight} />
         </div>
 
         {/* Productive */}

--- a/Frontend/src/page/protected/non-admin/dashboard/index.jsx
+++ b/Frontend/src/page/protected/non-admin/dashboard/index.jsx
@@ -234,7 +234,7 @@ const NonAdminDashboard = () => {
         </div>
 
         <div className="xl:col-span-3 col-span-12">
-          <EmpAi />
+          <EmpAi useStore={useNonAdminDashboardStore} />
         </div>
 
         {/* Productive / Non-Productive — gated by employee_insights_view */}


### PR DESCRIPTION
## Summary

The dashboard's **"Ask EMP AI Assistant"** panel previously showed a hardcoded mockup - four "Andrei Luca / Lorem ipsum" cards with no real data. This PR replaces it with **auto-generated, data-driven insight cards** built entirely from data the dashboard store already loads (no new API calls).

Each card surfaces a real signal and **opens the existing `ViewReportModal` in-place** when clicked, so the admin never leaves the dashboard.

## What the panel now shows

Cards are derived live and prioritized (most urgent first), capped at 12:

- **Roster:** absent today, idle now, offline, currently active, suspended accounts, total enrolled
- **Attendance rate** (present / enrolled)
- **Trends:** productivity up/down vs yesterday, idle-time spikes
- **Performers:** top performer, lowest performer, Top 10 Productive / Non-Productive / Active
- **Performance:** best location, best department
- **Usage:** top website, top application
- **Status:** an "all systems quiet" card when nobody is absent/idle/offline

When there's little activity data, the panel shows only the cards that have data, with a friendly empty/loading state otherwise.

## Implementation

- **`empAiInsights.js`** (new) - a pure, side-effect-free engine that takes the store snapshot and returns prioritized cards. Each card carries a `modal` descriptor (dataset + mode + title) rather than a route.
- **`EmpAi.jsx`** - renders the engine output with the original visual design and morph animation. Clicking a card calls `onOpenInsight(card)` (no navigation). Store-agnostic via a `useStore` prop so it works on both admin and non-admin dashboards.
- **`ViewReportModal.jsx`** - adds an `employee_list` mode that renders a plain roster (name / code / email / location / department) directly from `staticData`. This fixes "No data found" for roster cards: absent employees have no per-employee activity to fetch, so the old `employee_activity` mode returned empty.
- **admin `dashboard/index.jsx`** - resolves a clicked card's dataset to real store data and opens `ViewReportModal` in the correct mode.
- **non-admin `dashboard/index.jsx`** - injects its own store into `EmpAi`.

## Notes

- The big chat modal (`aempaiassistant/ChatUI`) is unchanged - it's still the separate canned-response stub and out of scope here.
- Non-admin dashboard cards are display-only for now (no modal wiring) - safe, no broken behavior.
- One pre-existing ESLint `set-state-in-effect` warning in `ViewReportModal`'s data effect is untouched (predates this PR).