### PR TITLE
Fix: edit-profile password fields blank, blocking save (#226)

### DIFF
--- a/Frontend/src/components/common/employee-details/EditEmployeeModal.jsx
+++ b/Frontend/src/components/common/employee-details/EditEmployeeModal.jsx
@@ -39,7 +39,11 @@ export default function EditEmployeeModal({ open, onOpenChange, employeeId, loca
       set("firstName",     d.name ?? d.first_name ?? "");
       set("lastName",      d.last_name ?? "");
       set("email",         d.email ?? "");
-      set("password",      d.password ?? "");
+      // Leave password / confirm-password blank in edit mode. The field is
+      // labelled "New Password (leave blank to keep)" and the backend preserves
+      // the existing password when none is sent. Prefilling with the stored
+      // (encrypted) password left confirm-password blank — so the two never
+      // matched and "Passwords do not match" blocked every save (issue #226).
       // phone may be stored as "countryCode-number" (e.g. "91-9876543210")
       const rawPhone = d.phone ?? "";
       const dashIdx = rawPhone.indexOf("-");


### PR DESCRIPTION
## Summary

Fixes #226 — *"In the employee details, when clicked on edit profile the confirm password is not showing, it's blank."*

When opening **Edit Employee**, the password field was prefilled with the stored *encrypted* password while the confirm-password field was left blank. The field is labelled **"New Password (leave blank to keep)"**, so it was never meant to be prefilled.

## Root cause

`EditEmployeeModal.jsx` ran `set("password", d.password ?? "")` when loading employee details. That single line caused three problems:

1. **Reported symptom** — the password field showed a value (dots) while confirm-password was blank, looking broken and inconsistent.
2. **Saving was impossible** — the validator's `form.password !== form.confirmPassword` check compared the encrypted blob against an empty string and raised **"Passwords do not match"** on every save attempt, blocking the admin unless they retyped the password in both fields.
3. **Latent corruption risk** — had it passed, the already-encrypted password would have been re-encrypted by the backend, breaking the employee's login.

## Fix

Don't prefill the password in edit mode — leave both password and confirm-password blank, matching the "leave blank to keep" design. The backend `updateProfile` handler already preserves the existing password when none is sent:

```js
} else {
    password = user_details[0].password; // keeps existing password when blank
}
```

## Resulting behavior

- Open Edit → both password fields are blank → other changes save freely (password preserved).
- To change the password → fill both fields → they're validated and the new password is encrypted once.

## Testing

- `npx eslint EditEmployeeModal.jsx` → passes (exit 0).
- Manual: edit an employee and save without touching passwords → saves successfully; set a new password in both fields → updates correctly.

One file changed, no new dependencies.
