### PR TITLE
Fix: AI Assistant chat scroll broken, sidebar scrolls with chat (#189)

### DIFF
--- a/Frontend/src/components/common/aempaiassistant/ChatUI.jsx
+++ b/Frontend/src/components/common/aempaiassistant/ChatUI.jsx
@@ -246,7 +246,7 @@ const ChatUI = ({ context }) => {
   const isEmpty = messages.length === 0;
 
   return (
-    <div className="flex-1 flex flex-col min-w-0 relative">
+    <div className="flex-1 flex flex-col min-w-0 min-h-0 relative">
       {/* Chat messages area */}
       <div className="flex-1 overflow-y-auto custom-scrollbar px-4 pt-14 pb-20 space-y-4">
         {isEmpty ? (

--- a/Frontend/src/components/common/aempaiassistant/ChatsView.jsx
+++ b/Frontend/src/components/common/aempaiassistant/ChatsView.jsx
@@ -8,7 +8,7 @@ const sampleChatHistory = [
 ];
 
 const ChatsView = ({ onNewChat }) => (
-  <div className="flex-1 flex flex-col min-w-0 relative">
+  <div className="flex-1 flex flex-col min-w-0 min-h-0 relative">
     {/* Header */}
     <div className="flex items-center justify-between px-6 pt-14 pb-4">
       <h2 className="text-2xl font-bold text-slate-800">Chats</h2>

--- a/Frontend/src/components/common/aempaiassistant/ProjectsView.jsx
+++ b/Frontend/src/components/common/aempaiassistant/ProjectsView.jsx
@@ -11,7 +11,7 @@ const sampleProjects = [
 ];
 
 const ProjectsView = ({ onNewChat }) => (
-  <div className="flex-1 flex flex-col min-w-0 relative">
+  <div className="flex-1 flex flex-col min-w-0 min-h-0 relative">
     {/* Header */}
     <div className="flex items-center justify-between px-6 pt-14 pb-4">
       <h2 className="text-2xl font-bold text-slate-800">Projects</h2>


### PR DESCRIPTION
## Summary

Fixes #189 — *UI scrolling issue in the EMP AI Assistant*: when a chat got long there was **no scrollbar to scroll back to earlier messages**, and the **sidebar scrolled along with the chat** instead of staying fixed.

## Root cause

A broken flexbox height chain. The assistant's view roots were `flex-1 flex flex-col min-w-0` but **missing `min-h-0`**. In a column flex layout, a flex item's automatic minimum height defaults to its *content* height — so with a long conversation the view grew past the modal instead of letting the inner `overflow-y-auto` message list scroll.

The overflow then bubbled up to the modal, and the auto-scroll's `scrollIntoView` ended up scrolling **the whole modal**. That single defect produced both reported symptoms:

- the message list never became a scroll container → **no scrollbar to reach the top**, and
- the modal itself was what moved → **the sidebar scrolled with the chat**.

## Fix

Add `min-h-0` to the view root so the inner list becomes the real scroll container. The chat now scrolls internally and the sidebar (a separate full-height flex column) stays fixed.

Applied to the three views that render in that slot and share the identical defect:

- `ChatUI.jsx` — the reported chat conversation
- `ChatsView.jsx` — chat history list
- `ProjectsView.jsx` — projects list

## Testing

- `npx eslint` on the changed files → no new errors introduced (each diff is a single `min-h-0` className addition).
- Manual: open the assistant, send enough messages to overflow → the messages area scrolls internally, the scroll-to-top works, and the sidebar stays put.

3 files changed, +3 / −3. No behavior or dependency changes — layout-only.
