### PR TITLE
chore(sidebar): remove Mobile Task, Reseller, and Addon Features menu…

### DIFF
--- a/Frontend/src/page/protected/admin/layout/AppSidebar.jsx
+++ b/Frontend/src/page/protected/admin/layout/AppSidebar.jsx
@@ -112,26 +112,6 @@ const getMenuItems = (t, { showAddonFeatures = false } = {}) => [
       { title: t("sidebar_alert_notification"), url: "/admin/behaviour/alertnotification" },
     ],
   },
-  {
-    title: t("sidebar_mobile_task"),
-    icon: Smartphone,
-    children: [
-      { title: t("sidebar_clients_users"), url: "/admin/mobiletask/clientuser" },
-      { title: t("sidebar_task_details"), url: "/admin/mobiletask/task" },
-      { title: t("sidebar_geo_location"), url: "/admin/mobiletask/geolocation" },
-    ],
-  },
-  {
-    title: t("reseller"),
-    icon: Store,
-    children: [
-      { title: t("dashboard"), url: "/admin/reseller/dashboard" },
-      { title: t("settings"), url: "/admin/reseller/settings" },
-    ],
-  },
-  ...(showAddonFeatures
-    ? [{ title: "Addon Features", url: "/admin/addon-features", icon: ToggleRight }]
-    : []),
 ];
 
 const normalizeResellerStats = (payload = {}) => {


### PR DESCRIPTION
… items

Remove the Mobile Task, Reseller, and Addon Features entries from the admin sidebar navigation. Routes and supporting logic are left intact.