### PR TITLE
feat(ai-assistant): gate EMP AI Assistant behind VITE_SHOW_EMP_AI_ASS…

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -9,3 +9,7 @@ VITE_BACKEND_V4_URL=http://localhost:3000
 
 VITE_CRYPTO_PASSWORD=your_secure_password
 VITE_PASSWORD_IV=your_secure_iv
+
+# Show the EMP AI Assistant (header button, dashboard "Ask EMP AI ASSISTANT"
+# card, and the AI icons on report cards) only when set to "true".
+VITE_SHOW_EMP_AI_ASSISTANT=false

--- a/Frontend/src/lib/utils.js
+++ b/Frontend/src/lib/utils.js
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
 }
+
+// EMP AI Assistant is gated behind an env flag — shown only when
+// VITE_SHOW_EMP_AI_ASSISTANT is explicitly set to "true".
+export function isEmpAiAssistantEnabled() {
+  return String(import.meta.env.VITE_SHOW_EMP_AI_ASSISTANT).toLowerCase() === "true";
+}

--- a/Frontend/src/page/protected/admin/dashboard/index.jsx
+++ b/Frontend/src/page/protected/admin/dashboard/index.jsx
@@ -28,6 +28,7 @@ import PerformanceFilter from "./PerformanceFilter";
 
 import { useDashboardStore } from "./dashboardStore";
 import { generateCombinedDashboardPdf } from "@/utils/dashboardPdfExport";
+import { isEmpAiAssistantEnabled } from "@/lib/utils";
 import { FileDown, Loader2, Calendar, CalendarDays, CalendarRange } from "lucide-react";
 import {
   Dialog,
@@ -105,6 +106,7 @@ const Dashboard = () => {
   const [periodDialogOpen, setPeriodDialogOpen] = useState(false);
   const [webTab, setWebTab] = useState("today");
   const [appTab, setAppTab] = useState("today");
+  const showEmpAiAssistant = isEmpAiAssistantEnabled();
 
   const openAiAssistant = useCallback((ctx) => {
     setAiContext(ctx);
@@ -636,13 +638,18 @@ const Dashboard = () => {
           <ActivitySnapshot data={activitySnapshot} />
         </div>
 
-        <div className="xl:col-span-5 col-span-12" data-pdf-section="breakdown">
+        <div
+          className={`${showEmpAiAssistant ? "xl:col-span-5" : "xl:col-span-8"} col-span-12`}
+          data-pdf-section="breakdown"
+        >
           <ActivityBreakDown data={activityBreakdown} />
         </div>
 
-        <div className="xl:col-span-3 col-span-12">
-          <EmpAi onOpenInsight={handleOpenInsight} />
-        </div>
+        {showEmpAiAssistant && (
+          <div className="xl:col-span-3 col-span-12">
+            <EmpAi onOpenInsight={handleOpenInsight} />
+          </div>
+        )}
 
         {/* Productive */}
 
@@ -656,7 +663,7 @@ const Dashboard = () => {
             report={
               <Customreport
                 title={t("top10productive")}
-                showShield
+                showShield={showEmpAiAssistant}
                 showButton
                 showMaximize
                 showDownload
@@ -709,7 +716,7 @@ const Dashboard = () => {
             report={
               <Customreport
                 title={t("top10nonproductive")}
-                showShield
+                showShield={showEmpAiAssistant}
                 showButton
                 showMaximize
                 showDownload
@@ -758,7 +765,7 @@ const Dashboard = () => {
             report={
               <Customreport
                 title={t("top10active")}
-                showShield
+                showShield={showEmpAiAssistant}
                 showButton
                 showMaximize
                 showDownload
@@ -808,7 +815,7 @@ const Dashboard = () => {
             report={
               <Customreport
                 title={t("top10nonactive")}
-                showShield
+                showShield={showEmpAiAssistant}
                 showButton
                 showMaximize
                 showDownload
@@ -858,7 +865,7 @@ const Dashboard = () => {
             report={
               <Customreport
                 title={t("locPerform")}
-                showShield
+                showShield={showEmpAiAssistant}
                 showButton
                 showMaximize
                 showDownload
@@ -900,7 +907,7 @@ const Dashboard = () => {
             report={
               <Customreport
                 title={t("deptPerform")}
-                showShield
+                showShield={showEmpAiAssistant}
                 showButton
                 showMaximize
                 showDownload
@@ -943,7 +950,7 @@ const Dashboard = () => {
             report={
               <Customreport
                 title={t("top10webUsage")}
-                showShield
+                showShield={showEmpAiAssistant}
                 showButton
                 showMaximize
                 showDownload
@@ -976,7 +983,7 @@ const Dashboard = () => {
             report={
               <Customreport
                 title={t("top10appUsage")}
-                showShield
+                showShield={showEmpAiAssistant}
                 showButton
                 showMaximize
                 showDownload
@@ -1082,11 +1089,13 @@ const Dashboard = () => {
         by={reportModal.by}
       />
 
-      <EmpAiAssistant
-        open={aiAssistantOpen}
-        onClose={() => setAiAssistantOpen(false)}
-        context={aiContext}
-      />
+      {showEmpAiAssistant && (
+        <EmpAiAssistant
+          open={aiAssistantOpen}
+          onClose={() => setAiAssistantOpen(false)}
+          context={aiContext}
+        />
+      )}
 
     </div>
 

--- a/Frontend/src/page/protected/admin/layout/TopBar.jsx
+++ b/Frontend/src/page/protected/admin/layout/TopBar.jsx
@@ -24,6 +24,7 @@ import UniPass from "@/components/common/UniPass";
 import BackToCloud from "@/components/BackToCloud";
 import aiWhiteLogo from "@/assets/ai_white_logo.svg";
 import EmpAiAssistant from "@/components/common/aempaiassistant";
+import { isEmpAiAssistantEnabled } from "@/lib/utils";
 import "./TopBar.css";
 
 export default function TopHeader() {
@@ -32,6 +33,7 @@ export default function TopHeader() {
   const { admin, clearAdmin } = useAdminSession();
   const [openUniPass, setOpenUniPass] = useState(false);
   const [aiAssistantOpen, setAiAssistantOpen] = useState(false);
+  const showEmpAiAssistant = isEmpAiAssistantEnabled();
   const navigate = useNavigate();
 
   const handleLogout = () => {
@@ -69,21 +71,23 @@ export default function TopHeader() {
       {/* Right — Actions */}
       <div className="flex items-center gap-4">
 
-        <div className="emp-ai-btn-wrap relative inline-flex">
-          <div
-            aria-hidden="true"
-            className="emp-ai-btn-glow pointer-events-none absolute -inset-0.5 rounded-[10px]"
-          />
-          <button
-            type="button"
-            onClick={() => setAiAssistantOpen(true)}
-            aria-label="Open EmpMonitor AI Assistant"
-            className="emp-ai-btn relative flex items-center gap-1.5 rounded-[9px] px-3 py-1.5 cursor-pointer text-white text-[10px] font-semibold"
-          >
-            <img src={aiWhiteLogo} alt="" className="h-3.75" />
-            EMP AI ASSISTANT
-          </button>
-        </div>
+        {showEmpAiAssistant && (
+          <div className="emp-ai-btn-wrap relative inline-flex">
+            <div
+              aria-hidden="true"
+              className="emp-ai-btn-glow pointer-events-none absolute -inset-0.5 rounded-[10px]"
+            />
+            <button
+              type="button"
+              onClick={() => setAiAssistantOpen(true)}
+              aria-label="Open EmpMonitor AI Assistant"
+              className="emp-ai-btn relative flex items-center gap-1.5 rounded-[9px] px-3 py-1.5 cursor-pointer text-white text-[10px] font-semibold"
+            >
+              <img src={aiWhiteLogo} alt="" className="h-3.75" />
+              EMP AI ASSISTANT
+            </button>
+          </div>
+        )}
 
         <BackToCloud />
 
@@ -190,10 +194,12 @@ export default function TopHeader() {
 
        <UniPass isOpen={openUniPass} onClose={() => setOpenUniPass(false)}/>
 
-       <EmpAiAssistant
-         open={aiAssistantOpen}
-         onClose={() => setAiAssistantOpen(false)}
-       />
+       {showEmpAiAssistant && (
+         <EmpAiAssistant
+           open={aiAssistantOpen}
+           onClose={() => setAiAssistantOpen(false)}
+         />
+       )}
     </div>
 
   );

--- a/Frontend/src/page/protected/non-admin/dashboard/index.jsx
+++ b/Frontend/src/page/protected/non-admin/dashboard/index.jsx
@@ -21,6 +21,7 @@ import PerformanceFilter from "../../admin/dashboard/PerformanceFilter";
 import { useNonAdminDashboardStore } from "./dashboardStore";
 import useNonAdminSession from "../../../../sessions/useNonAdminSession";
 import { usePermission }  from "../../../../hooks/usePermission";
+import { isEmpAiAssistantEnabled } from "@/lib/utils";
 
 // ── PDF export helpers (shared across modules) ──────────────────────
 const fmtDuration = (sec) => {
@@ -47,6 +48,7 @@ const NonAdminDashboard = () => {
   const { t } = useTranslation();
   const { nonAdmin }   = useNonAdminSession();
   const { canView }    = usePermission(nonAdmin);
+  const showEmpAiAssistant = isEmpAiAssistantEnabled();
 
   const {
     stats,
@@ -174,7 +176,7 @@ const NonAdminDashboard = () => {
   const makeControls = ({ pdfTitle, pdfSubtitle, pdfMeta, pdfData, pdfColumns } = {}) => (
     <Customreport
       title={pdfTitle}
-      showShield
+      showShield={showEmpAiAssistant}
       showButton
       showMaximize
       showDownload
@@ -229,13 +231,15 @@ const NonAdminDashboard = () => {
           <ActivitySnapshot data={activitySnapshot} />
         </div>
 
-        <div className="xl:col-span-5 col-span-12">
+        <div className={`${showEmpAiAssistant ? "xl:col-span-5" : "xl:col-span-8"} col-span-12`}>
           <ActivityBreakDown data={activityBreakdown} />
         </div>
 
-        <div className="xl:col-span-3 col-span-12">
-          <EmpAi useStore={useNonAdminDashboardStore} />
-        </div>
+        {showEmpAiAssistant && (
+          <div className="xl:col-span-3 col-span-12">
+            <EmpAi useStore={useNonAdminDashboardStore} />
+          </div>
+        )}
 
         {/* Productive / Non-Productive — gated by employee_insights_view */}
         {showInsights && (


### PR DESCRIPTION
…ISTANT

Show the EMP AI Assistant only when VITE_SHOW_EMP_AI_ASSISTANT is set to "true", otherwise hide all of its entry points:

- Header "EMP AI ASSISTANT" button (admin TopBar)
- Dashboard "Ask EMP AI ASSISTANT" card (admin + non-admin)
- AI feather icons on report cards (showShield)
- The assistant panel itself

Adds isEmpAiAssistantEnabled() helper in lib/utils and documents the new flag in .env.example. The activity breakdown column widens to fill the freed space when the card is hidden.