### PR TITLE
fix(i18n): translate hardcoded strings on the Real-Time Insights page

### DIFF
--- a/Frontend/src/components/common/employee-realtime-insights/EmployeeCard.jsx
+++ b/Frontend/src/components/common/employee-realtime-insights/EmployeeCard.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react"
 import { BarChart3, Download, MapPin } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 const avatarColors = [
     "bg-blue-500",
@@ -27,6 +28,7 @@ const statusColorMap = {
 }
 
 function EmployeeCard({ emp, isSelected, onSelect, onAnalytics, onDownload, idx }) {
+    const { t } = useTranslation()
     const activity = emp.activity
 
     const handleClick = useCallback(() => onSelect(emp.id), [onSelect, emp.id])
@@ -73,7 +75,7 @@ function EmployeeCard({ emp, isSelected, onSelect, onAnalytics, onDownload, idx 
             <div className="flex items-center justify-between mb-2">
                 <div>
                     <span className="text-[11px] text-slate-500">
-                        Productivity :{" "}
+                        {t("productivity")} :{" "}
                     </span>
                     <span className="text-[11px] font-bold text-slate-800">
                         {emp.productivity}
@@ -87,22 +89,22 @@ function EmployeeCard({ emp, isSelected, onSelect, onAnalytics, onDownload, idx 
             {/* Timesheet Hours */}
             <div className="flex flex-wrap gap-x-3 gap-y-0.5 mb-2">
                 <p className="text-[10px] text-slate-500">
-                    <span className="font-semibold">Office:</span>{" "}
+                    <span className="font-semibold">{t("office")}:</span>{" "}
                     <span className="text-slate-700">{emp.officeHours}</span>
                 </p>
                 <p className="text-[10px] text-slate-500">
-                    <span className="font-semibold">Active:</span>{" "}
+                    <span className="font-semibold">{t("actives")}:</span>{" "}
                     <span className="text-slate-700">{emp.activeHours}</span>
                 </p>
                 <p className="text-[10px] text-slate-500">
-                    <span className="font-semibold">Idle:</span>{" "}
+                    <span className="font-semibold">{t("idles")}:</span>{" "}
                     <span className="text-slate-700">{emp.idleHours}</span>
                 </p>
             </div>
 
             {/* Email */}
             <div className="mb-2">
-                <span className="text-[11px] text-slate-500">Email : </span>
+                <span className="text-[11px] text-slate-500">{t("email")} : </span>
                 <span className="text-[11px] text-slate-600">
                     {emp.email}
                 </span>
@@ -113,19 +115,19 @@ function EmployeeCard({ emp, isSelected, onSelect, onAnalytics, onDownload, idx 
                 <div className="mb-3 space-y-0.5">
                     {activity.title && (
                         <p className="text-[11px] text-slate-600">
-                            <span className="font-semibold text-slate-500">Title: </span>
+                            <span className="font-semibold text-slate-500">{t("title")}: </span>
                             {getSubstring(activity.title)}
                         </p>
                     )}
                     {activity.appName && (
                         <p className="text-[11px] text-slate-600">
-                            <span className="font-semibold text-slate-500">App: </span>
+                            <span className="font-semibold text-slate-500">{t("appLabel")}: </span>
                             {getSubstring(activity.appName)}
                         </p>
                     )}
                     {activity.currentUrl && (
                         <p className="text-[11px] text-slate-600">
-                            <span className="font-semibold text-slate-500">URL: </span>
+                            <span className="font-semibold text-slate-500">{t("url")}: </span>
                             <a
                                 href={activity.currentUrl}
                                 target="_blank"
@@ -142,10 +144,10 @@ function EmployeeCard({ emp, isSelected, onSelect, onAnalytics, onDownload, idx 
 
             {/* Footer icons */}
             <div className="flex items-center gap-2 border-t border-slate-100 pt-2.5">
-                <button onClick={(e) => { e.stopPropagation(); onDownload?.(emp); }} title="Download" className="w-6 h-6 rounded-md bg-emerald-100 hover:bg-emerald-200 flex items-center justify-center transition-colors">
+                <button onClick={(e) => { e.stopPropagation(); onDownload?.(emp); }} title={t("downloads")} className="w-6 h-6 rounded-md bg-emerald-100 hover:bg-emerald-200 flex items-center justify-center transition-colors">
                     <Download className="w-3 h-3 text-emerald-600" />
                 </button>
-                <button onClick={(e) => { e.stopPropagation(); onAnalytics?.(emp); }} title="Analytics" className="w-6 h-6 rounded-md bg-blue-100 hover:bg-blue-200 flex items-center justify-center transition-colors">
+                <button onClick={(e) => { e.stopPropagation(); onAnalytics?.(emp); }} title={t("analytics")} className="w-6 h-6 rounded-md bg-blue-100 hover:bg-blue-200 flex items-center justify-center transition-colors">
                     <BarChart3 className="w-3 h-3 text-blue-500" />
                 </button>
                 {activity?.latitude && activity?.longitude && (

--- a/Frontend/src/components/common/employee-realtime-insights/Headers.jsx
+++ b/Frontend/src/components/common/employee-realtime-insights/Headers.jsx
@@ -1,22 +1,24 @@
 import React from "react";
 import { Activity } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 function Headers({ isConnected }) {
+    const { t } = useTranslation();
     return (
         <div className="flex flex-wrap items-start justify-between gap-4 mb-6">
             <div className="border-l-4 border-blue-600 pl-4">
                 <div className="flex items-center gap-2">
                     <h2 className="text-gray-800" style={{ fontSize: "21px", lineHeight: "18px" }}>
-                        <span className="font-semibold">Employee&apos;s</span>{" "}
-                        <span className="font-normal text-gray-500">Real Time Insights</span>
+                        <span className="font-semibold">{t("realtimeInsightsEmployees")}</span>{" "}
+                        <span className="font-normal text-gray-500">{t("realtimeInsightsTitle")}</span>
                     </h2>
                     <span
                         className={`w-2 h-2 rounded-full mt-1 ${isConnected ? "bg-green-500" : "bg-slate-300"}`}
-                        title={isConnected ? "Live" : "Disconnected"}
+                        title={isConnected ? t("statusLive") : t("statusDisconnected")}
                     />
                 </div>
                 <p className="text-xs text-gray-400 mt-1 max-w-sm leading-tight">
-                    &quot;A realtime analysis of employee. Every second counts in tracking&quot;
+                    &quot;{t("realtimeInsightsSubtitle")}&quot;
                 </p>
             </div>
             <div className="shrink-0 hidden sm:block">

--- a/Frontend/src/components/common/employee-realtime-insights/ProductivitySlider.jsx
+++ b/Frontend/src/components/common/employee-realtime-insights/ProductivitySlider.jsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from "react";
+import { useTranslation } from "react-i18next";
 
 function ProductivitySlider({ minValue, maxValue, onMinChange, onMaxChange }) {
+    const { t } = useTranslation();
     const handleMinChange = useCallback(
         (e) => {
             const val = Math.min(Number(e.target.value), maxValue - 1);
@@ -20,7 +22,7 @@ function ProductivitySlider({ minValue, maxValue, onMinChange, onMaxChange }) {
     return (
         <div className="flex-1 max-w-md">
             <label className="block text-sm font-medium text-slate-700 mb-2">
-                Productivity tracker
+                {t("productivityTracker")}
             </label>
             <div className="relative pt-8">
                 {/* Min tooltip */}

--- a/Frontend/src/components/common/employee-realtime-insights/SearchSection.jsx
+++ b/Frontend/src/components/common/employee-realtime-insights/SearchSection.jsx
@@ -1,17 +1,19 @@
 import React from "react";
 import { Search } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 
 function SearchSection({ search, setSearch }) {
+    const { t } = useTranslation();
     return (
         <div>
             <label className="block text-sm font-medium text-slate-700 mb-1.5">
-                Search
+                {t("search")}
             </label>
             <div className="relative w-full max-w-[200px]">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
                 <Input
-                    placeholder="Search"
+                    placeholder={t("search")}
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     className="pl-9 h-10 rounded-full bg-slate-50 border-slate-200 text-xs"

--- a/Frontend/src/i18n/ar.json
+++ b/Frontend/src/i18n/ar.json
@@ -1460,5 +1460,13 @@
   "reseller.pngOnly": "PNG فقط. الحد الأقصى",
   "reseller.imageTooLarge": "الصورة كبيرة جداً",
   "reseller.maxDimensions": "الأبعاد القصوى",
-  "reseller.error": "خطأ"
+  "reseller.error": "خطأ",
+  "realtimeInsightsTitle": "رؤى في الوقت الفعلي",
+  "realtimeInsightsEmployees": "الموظف",
+  "realtimeInsightsSubtitle": "تحليل فوري للموظف. كل ثانية مهمة في التتبع",
+  "productivityTracker": "متتبع الإنتاجية",
+  "statusLive": "مباشر",
+  "statusDisconnected": "غير متصل",
+  "appLabel": "تطبيق",
+  "analytics": "التحليلات"
 }

--- a/Frontend/src/i18n/en.json
+++ b/Frontend/src/i18n/en.json
@@ -1455,5 +1455,13 @@
   "reseller.pngOnly": "PNG only. Max",
   "reseller.imageTooLarge": "Image too large",
   "reseller.maxDimensions": "Max dimensions",
-  "reseller.error": "Error"
+  "reseller.error": "Error",
+  "realtimeInsightsTitle": "Real Time Insights",
+  "realtimeInsightsEmployees": "Employee's",
+  "realtimeInsightsSubtitle": "A realtime analysis of employee. Every second counts in tracking",
+  "productivityTracker": "Productivity tracker",
+  "statusLive": "Live",
+  "statusDisconnected": "Disconnected",
+  "appLabel": "App",
+  "analytics": "Analytics"
 }

--- a/Frontend/src/i18n/es.json
+++ b/Frontend/src/i18n/es.json
@@ -1455,5 +1455,13 @@
   "reseller.pngOnly": "Solo PNG. Máx",
   "reseller.imageTooLarge": "Imagen demasiado grande",
   "reseller.maxDimensions": "Dimensiones máximas",
-  "reseller.error": "Error"
+  "reseller.error": "Error",
+  "realtimeInsightsTitle": "Informaciones en Tiempo Real",
+  "realtimeInsightsEmployees": "Del Empleado",
+  "realtimeInsightsSubtitle": "Un análisis en tiempo real del empleado. Cada segundo cuenta en el seguimiento",
+  "productivityTracker": "Rastreador de productividad",
+  "statusLive": "En vivo",
+  "statusDisconnected": "Desconectado",
+  "appLabel": "Aplicación",
+  "analytics": "Analíticas"
 }

--- a/Frontend/src/i18n/fr.json
+++ b/Frontend/src/i18n/fr.json
@@ -1455,5 +1455,13 @@
   "reseller.pngOnly": "PNG uniquement. Max",
   "reseller.imageTooLarge": "Image trop grande",
   "reseller.maxDimensions": "Dimensions maximales",
-  "reseller.error": "Erreur"
+  "reseller.error": "Erreur",
+  "realtimeInsightsTitle": "Aperçus en Temps Réel",
+  "realtimeInsightsEmployees": "De l'Employé",
+  "realtimeInsightsSubtitle": "Une analyse en temps réel de l'employé. Chaque seconde compte dans le suivi",
+  "productivityTracker": "Suivi de productivité",
+  "statusLive": "En direct",
+  "statusDisconnected": "Déconnecté",
+  "appLabel": "Application",
+  "analytics": "Analytique"
 }

--- a/Frontend/src/i18n/idn.json
+++ b/Frontend/src/i18n/idn.json
@@ -1455,5 +1455,13 @@
   "reseller.pngOnly": "Hanya PNG. Maks",
   "reseller.imageTooLarge": "Gambar terlalu besar",
   "reseller.maxDimensions": "Dimensi maksimal",
-  "reseller.error": "Kesalahan"
+  "reseller.error": "Kesalahan",
+  "realtimeInsightsTitle": "Wawasan Waktu Nyata",
+  "realtimeInsightsEmployees": "Karyawan",
+  "realtimeInsightsSubtitle": "Analisis karyawan secara waktu nyata. Setiap detik penting dalam pelacakan",
+  "productivityTracker": "Pelacak Produktivitas",
+  "statusLive": "Langsung",
+  "statusDisconnected": "Terputus",
+  "appLabel": "Aplikasi",
+  "analytics": "Analitik"
 }

--- a/Frontend/src/i18n/pt.json
+++ b/Frontend/src/i18n/pt.json
@@ -1455,5 +1455,13 @@
   "reseller.pngOnly": "Apenas PNG. Máx",
   "reseller.imageTooLarge": "Imagem muito grande",
   "reseller.maxDimensions": "Dimensões máximas",
-  "reseller.error": "Erro"
+  "reseller.error": "Erro",
+  "realtimeInsightsTitle": "Insights em Tempo Real",
+  "realtimeInsightsEmployees": "Do Funcionário",
+  "realtimeInsightsSubtitle": "Uma análise em tempo real do funcionário. Cada segundo conta no rastreamento",
+  "productivityTracker": "Rastreador de produtividade",
+  "statusLive": "Ao vivo",
+  "statusDisconnected": "Desconectado",
+  "appLabel": "Aplicativo",
+  "analytics": "Análises"
 }


### PR DESCRIPTION
## Fix mixed-language rendering on the Real-Time Insights page

The **Employee Real-Time Insights** page rendered a **mix of the selected language and English**. Under Indonesian, for example, the page showed English text like "Employee's Real Time Insights", "Search", "Productivity tracker", "Office / Active / Idle", and "Email" while the rest of the UI was translated.

### Root cause

Not missing translations — the locale bundles are complete (`idn.json` has all 1459 keys). The problem was that several strings in the page's components were **hardcoded literals** that never went through `t()`, so they couldn't switch language no matter which locale was active.

### Fix

- Wire the four page components — `Headers`, `SearchSection`, `ProductivitySlider`, `EmployeeCard` — to `useTranslation()` / `t()`.
- **Reuse existing keys** where they already exist: `search`, `productivity`, `office`, `actives`, `idles`, `email`, `title`, `url`, `downloads`.
- **Add 8 new keys** for strings that had none, translated across all six locales (en, idn, es, fr, pt, ar):
  `realtimeInsightsTitle`, `realtimeInsightsEmployees`, `realtimeInsightsSubtitle`, `productivityTracker`, `statusLive`, `statusDisconnected`, `appLabel`, `analytics`.

### Result

The page now fully translates with the selected language — no hardcoded UI text remains in these components.

Example (Indonesian):

| Before (hardcoded English) | After (translated) |
|---|---|
| Employee's Real Time Insights | Karyawan Wawasan Waktu Nyata |
| Search | Cari |
| Productivity tracker | Pelacak Produktivitas |
| Office / Active / Idle | Kantor / Aktif / Diam |
| Email / App / Title / URL | Surel / Aplikasi / Judul / URL |

### Scope / verification

- 4 components + 6 locale files changed; the locale edits are additive (8 new keys per file), no existing keys touched.
- Lint clean on the changed files; Vite serves all four updated components.
- Verified the new keys resolve in every locale.
