### PR TITLE
feat(monitoring): remove the Webcam Cast toggle from the UI

### DIFF
--- a/Frontend/src/components/common/monitoring-control/dialog/MonitoringControlDialog.jsx
+++ b/Frontend/src/components/common/monitoring-control/dialog/MonitoringControlDialog.jsx
@@ -545,12 +545,6 @@ const MonitoringControlDialog = ({ open, onOpenChange }) => {
                             {!isOnPremise() && (
                                 <>
                                     <ToggleRow
-                                        label="Webcam Casting"
-                                        name="webCamCasting"
-                                        value={rules.features?.webCamCasting}
-                                        onChange={(v) => updateRule("features.webCamCasting", v)}
-                                    />
-                                    <ToggleRow
                                         label="File Upload Detection"
                                         name="file_upload_detection"
                                         value={rules.features?.file_upload_detection}

--- a/Frontend/src/components/common/monitoring-control/dialog/MonitoringControlDialog.jsx
+++ b/Frontend/src/components/common/monitoring-control/dialog/MonitoringControlDialog.jsx
@@ -541,35 +541,6 @@ const MonitoringControlDialog = ({ open, onOpenChange }) => {
                                 value={rules.features?.screencast}
                                 onChange={(v) => updateRule("features.screencast", v)}
                             />
-                            {/* Cloud-only features — hidden on on-premise deployments */}
-                            {!isOnPremise() && (
-                                <>
-                                    <ToggleRow
-                                        label="File Upload Detection"
-                                        name="file_upload_detection"
-                                        value={rules.features?.file_upload_detection}
-                                        onChange={(v) => updateRule("features.file_upload_detection", v)}
-                                    />
-                                    <ToggleRow
-                                        label="File Upload Blocking"
-                                        name="file_upload_blocking"
-                                        value={rules.features?.file_upload_blocking}
-                                        onChange={(v) => updateRule("features.file_upload_blocking", v)}
-                                    />
-                                    <ToggleRow
-                                        label="Print Detection"
-                                        name="print_detection"
-                                        value={rules.features?.print_detection}
-                                        onChange={(v) => updateRule("features.print_detection", v)}
-                                    />
-                                    <ToggleRow
-                                        label="Print Blocking"
-                                        name="print_blocking"
-                                        value={rules.features?.print_blocking}
-                                        onChange={(v) => updateRule("features.print_blocking", v)}
-                                    />
-                                </>
-                            )}
                             <ToggleRow
                                 label="Manual Log Entry"
                                 name="manual_clock_in"

--- a/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
+++ b/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
@@ -376,7 +376,7 @@ export default function TrackEmp() {
           </Section>
 
           {/* Tracking + DLP / Screenshots / Agent */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
             <Section title={t("track_tracking_features")} icon={<Shield size={14} className="text-red-400" />}>
               <div className="bg-[#f5f7fb] rounded-xl p-3">
                 <div className="grid grid-cols-[minmax(0,1fr)_200px_140px] gap-2 items-center px-2 py-2 mb-1 bg-gray-200/60 rounded-md">

--- a/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
+++ b/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
@@ -44,14 +44,14 @@ const RadioPair = ({ value, onChange }) => {
 };
 
 const Section = ({ title, icon, children }) => (
-  <div className="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden">
+  <div className="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden flex flex-col">
     {title && (
       <div className="flex items-center gap-2.5 px-5 py-3 border-b border-[#CAEDFF]" style={{ background: "#CAEDFF" }}>
         {icon}
         <h3 className="text-[13px] font-extrabold text-gray-800 tracking-tight">{title}</h3>
       </div>
     )}
-    <div className="px-5 py-4">{children}</div>
+    <div className="px-5 py-4 flex-1 flex flex-col justify-center">{children}</div>
   </div>
 );
 
@@ -376,7 +376,7 @@ export default function TrackEmp() {
           </Section>
 
           {/* Tracking + DLP / Screenshots / Agent */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-stretch">
             <Section title={t("track_tracking_features")} icon={<Shield size={14} className="text-red-400" />}>
               <div className="bg-[#f5f7fb] rounded-xl p-3">
                 <div className="grid grid-cols-[minmax(0,1fr)_200px_140px] gap-2 items-center px-2 py-2 mb-1 bg-gray-200/60 rounded-md">
@@ -476,7 +476,7 @@ export default function TrackEmp() {
               )}
             </Section>
 
-            <div className="space-y-4">
+            <div className="flex flex-col gap-4 h-full [&>*]:flex-1">
               {/* DLP */}
               <Section title={t("track_dlp_features")} icon={<Shield size={14} className="text-orange-400" />}>
                 <FeatureRow label={t("track_bluetooth_detection")} value={settings.dlp.bluetoothDetection} onChange={(v) => set("dlp.bluetoothDetection", v)} />

--- a/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
+++ b/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
@@ -407,9 +407,6 @@ export default function TrackEmp() {
                   <FeatureRow label={t("track_geo_location_logs")} value={settings.features.geoLocationLogs} onChange={(v) => set("features.geoLocationLogs", v)} showAdvancedColumn />
                 )}
                 <FeatureRow label={t("track_screen_casting")} value={settings.features.screenCasting} onChange={(v) => set("features.screenCasting", v)} showAdvancedColumn />
-                {!isOnPremise() && (
-                  <FeatureRow label={t("track_webcam_cast")} value={settings.features.webcamCast} onChange={(v) => set("features.webcamCast", v)} showAdvancedColumn />
-                )}
               </div>
               {advancedPanel && (
                 <div className="fixed inset-0 z-[99999] bg-slate-900/60 flex items-center justify-center" onClick={() => setAdvancedPanel(null)}>

--- a/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
+++ b/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
@@ -375,8 +375,8 @@ export default function TrackEmp() {
             </div>
           </Section>
 
-          {/* Tracking + DLP / Screenshots / Agent */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+          {/* Tracking Features (full width), then DLP / Screenshots / Agent in a row */}
+          <div className="flex flex-col gap-4">
             <Section title={t("track_tracking_features")} icon={<Shield size={14} className="text-red-400" />}>
               <div className="bg-[#f5f7fb] rounded-xl p-3">
                 <div className="grid grid-cols-[minmax(0,1fr)_200px_140px] gap-2 items-center px-2 py-2 mb-1 bg-gray-200/60 rounded-md">
@@ -476,7 +476,7 @@ export default function TrackEmp() {
               )}
             </Section>
 
-            <div className="flex flex-col gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-start">
               {/* DLP */}
               <Section title={t("track_dlp_features")} icon={<Shield size={14} className="text-orange-400" />}>
                 <FeatureRow label={t("track_bluetooth_detection")} value={settings.dlp.bluetoothDetection} onChange={(v) => set("dlp.bluetoothDetection", v)} />

--- a/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
+++ b/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
@@ -375,8 +375,8 @@ export default function TrackEmp() {
             </div>
           </Section>
 
-          {/* Tracking Features (full width), then DLP / Screenshots / Agent in a row */}
-          <div className="flex flex-col gap-4">
+          {/* Tracking + DLP / Screenshots / Agent */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
             <Section title={t("track_tracking_features")} icon={<Shield size={14} className="text-red-400" />}>
               <div className="bg-[#f5f7fb] rounded-xl p-3">
                 <div className="grid grid-cols-[minmax(0,1fr)_200px_140px] gap-2 items-center px-2 py-2 mb-1 bg-gray-200/60 rounded-md">
@@ -476,7 +476,7 @@ export default function TrackEmp() {
               )}
             </Section>
 
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-start">
+            <div className="flex flex-col gap-6">
               {/* DLP */}
               <Section title={t("track_dlp_features")} icon={<Shield size={14} className="text-orange-400" />}>
                 <FeatureRow label={t("track_bluetooth_detection")} value={settings.dlp.bluetoothDetection} onChange={(v) => set("dlp.bluetoothDetection", v)} />

--- a/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
+++ b/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
@@ -44,14 +44,14 @@ const RadioPair = ({ value, onChange }) => {
 };
 
 const Section = ({ title, icon, children }) => (
-  <div className="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden flex flex-col">
+  <div className="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden">
     {title && (
       <div className="flex items-center gap-2.5 px-5 py-3 border-b border-[#CAEDFF]" style={{ background: "#CAEDFF" }}>
         {icon}
         <h3 className="text-[13px] font-extrabold text-gray-800 tracking-tight">{title}</h3>
       </div>
     )}
-    <div className="px-5 py-4 flex-1 flex flex-col justify-center">{children}</div>
+    <div className="px-5 py-4">{children}</div>
   </div>
 );
 
@@ -376,7 +376,7 @@ export default function TrackEmp() {
           </Section>
 
           {/* Tracking + DLP / Screenshots / Agent */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-stretch">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
             <Section title={t("track_tracking_features")} icon={<Shield size={14} className="text-red-400" />}>
               <div className="bg-[#f5f7fb] rounded-xl p-3">
                 <div className="grid grid-cols-[minmax(0,1fr)_200px_140px] gap-2 items-center px-2 py-2 mb-1 bg-gray-200/60 rounded-md">
@@ -476,7 +476,7 @@ export default function TrackEmp() {
               )}
             </Section>
 
-            <div className="flex flex-col gap-4 h-full [&>*]:flex-1">
+            <div className="flex flex-col gap-6">
               {/* DLP */}
               <Section title={t("track_dlp_features")} icon={<Shield size={14} className="text-orange-400" />}>
                 <FeatureRow label={t("track_bluetooth_detection")} value={settings.dlp.bluetoothDetection} onChange={(v) => set("dlp.bluetoothDetection", v)} />

--- a/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
+++ b/Frontend/src/page/protected/admin/track-user-settings/TrackEmp.jsx
@@ -390,15 +390,6 @@ export default function TrackEmp() {
                 <FeatureRow label={t("track_screenshots")} value={settings.features.screenshots} onChange={(v) => set("features.screenshots", v)} hasAdvanced onAdvancedClick={(label) => setAdvancedPanel(advancedPanel === label ? null : label)} showAdvancedColumn />
                 <FeatureRow label={t("track_screen_recording")} value={settings.features.screenRecording} onChange={(v) => set("features.screenRecording", v)} showAdvancedColumn />
                 <FeatureRow label={t("track_screen_recording_with_voice")} value={settings.features.screenRecordingWithVoice} onChange={(v) => set("features.screenRecordingWithVoice", v)} infoIcon showAdvancedColumn />
-                {/* Cloud-only features — hidden on on-premise deployments */}
-                {!isOnPremise() && (
-                  <>
-                    <FeatureRow label={t("track_file_upload_detection")} value={settings.features.fileUploadDetection} onChange={(v) => set("features.fileUploadDetection", v)} showAdvancedColumn />
-                    <FeatureRow label={t("track_file_upload_blocking")} value={settings.features.fileUploadBlocking} onChange={(v) => set("features.fileUploadBlocking", v)} showAdvancedColumn />
-                    <FeatureRow label={t("track_print_blocking")} value={settings.features.printBlocking} onChange={(v) => set("features.printBlocking", v)} showAdvancedColumn />
-                    <FeatureRow label={t("track_print_detection")} value={settings.features.printDetection} onChange={(v) => set("features.printDetection", v)} showAdvancedColumn />
-                  </>
-                )}
                 <FeatureRow label={t("track_manual_clock_in_and_out")} value={settings.features.manualClockInOut} onChange={(v) => set("features.manualClockInOut", v)} showAdvancedColumn />
                 <FeatureRow label={t("track_usb_blocking")} value={settings.features.usbBlocking} onChange={(v) => set("features.usbBlocking", v)} showAdvancedColumn />
                 <FeatureRow label={t("track_attendance_override")} value={settings.features.attendanceOverride} onChange={(v) => set("features.attendanceOverride", v)} showAdvancedColumn />


### PR DESCRIPTION
## Remove the Webcam Cast toggle from the UI

Removes the **Webcam Cast** / **Webcam Casting** feature toggle from both places it appeared:

- the **Track User Settings** page (`TrackEmp.jsx`)
- the **Monitoring Control** dialog (`MonitoringControlDialog.jsx`)

### Scope

Only the operator-facing toggle is removed. The API field mapping in `service.js` (`webcamCast` ↔ `webCamCasting`) and the store default are left **intact**, so existing saved settings and the request/response contract are unaffected.

2 files changed, 9 deletions.