### PR TITLE
fix(timeclaim): hide Create Request on the admin page

### DIFF
--- a/Frontend/src/components/common/timeclaim/EmpTimeclaim.jsx
+++ b/Frontend/src/components/common/timeclaim/EmpTimeclaim.jsx
@@ -740,7 +740,7 @@ const Spinner = () => (
 
 // ─── Main Component ─────────────────────────────────────────────────────────
 
-const EmpTimeclaim = ({ isEmployee = false }) => {
+const EmpTimeclaim = ({ isEmployee = false, isAdmin = false }) => {
   const { t } = useTranslation();
   const REQUEST_TYPE_OPTIONS = getRequestTypeOptions(t);
   const STATUS_OPTIONS = getStatusOptions(t);
@@ -881,7 +881,9 @@ const EmpTimeclaim = ({ isEmployee = false }) => {
           </p>
         </div>
         <div className="flex items-center gap-4">
-          {filters.requestType !== REQUEST_TYPES.BREAK && (
+          {/* Create Request is for employees/managers to raise claims — admins
+              only review & approve, so it's hidden on the admin page. */}
+          {!isAdmin && filters.requestType !== REQUEST_TYPES.BREAK && (
             <Button
               size="lg"
               className="rounded-xl bg-blue-500 hover:bg-blue-600 px-5 text-xs font-semibold shadow-sm"

--- a/Frontend/src/page/protected/admin/time-claim/index.jsx
+++ b/Frontend/src/page/protected/admin/time-claim/index.jsx
@@ -4,6 +4,8 @@ import EmpTimeclaim from '@/components/common/timeclaim/EmpTimeclaim'
 
 export const TimeClaim = () => (
   <div className="bg-slate-200 w-full min-h-screen p-5">
-    <EmpTimeclaim />
+    {/* Admin can review/approve requests but not raise them — hide "Create
+        Request". Non-admin (manager) and employee pages keep it. */}
+    <EmpTimeclaim isAdmin />
   </div>
 )


### PR DESCRIPTION
## Hide "Create Request" on the admin Time Claim page

On `/admin/timeclaim`, the **Create Request** button was showing. Time-claim requests are raised by **employees and managers (non-admin)**; admins only **review and approve** them — so the button doesn't belong on the admin page.

### Change
- `admin/time-claim/index.jsx` now renders `<EmpTimeclaim isAdmin />`.
- `EmpTimeclaim` gains an `isAdmin` prop; the **Create Request** button is gated on `!isAdmin`.

The button is the only trigger for the create-request modal, so admins can no longer raise a claim — they keep review / approve / decline, filters, and auto-approve. Non-admin and employee pages are unchanged.

### Behavior
| Page | Create Request |
|---|---|
| Admin (`/admin/timeclaim`) | Hidden |
| Non-admin / manager | Shown (unchanged) |
| Employee | Shown (unchanged) |

### Verification
- `vite build`: **passes** (exit 0).
- Verified in the running app: hidden on admin, still present on non-admin/employee.
- Minimal diff (prop + gate); the eslint notices in this file are pre-existing on untouched code.
