### PR TITLE
style(usb-detection): full-width filter dropdowns + smoother grid

### DIFF
--- a/Frontend/src/components/common/usb-detection/EmpUsbDetection.jsx
+++ b/Frontend/src/components/common/usb-detection/EmpUsbDetection.jsx
@@ -59,18 +59,21 @@ const EmpUsbDetection = () => {
       </div>
 
       {/* Filters */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5 gap-x-6 gap-y-4 mb-5">
+      {/* [&>*]:min-w-0 lets grid children shrink instead of overflowing, and the
+          xl step smooths the jump to 5 columns; each CustomSelect gets width so
+          it fills its cell (w-full) for a clean, edge-aligned filter bar. */}
+      <div className="[&>*]:min-w-0 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-5 gap-x-6 gap-y-4 mb-5">
         <div>
           <label className="block text-sm font-medium text-slate-700 mb-1.5">{t("location")}</label>
-          <CustomSelect placeholder={t("allLocations")} items={locations} selected={filters.locationId} onChange={handleLocationChange} />
+          <CustomSelect width placeholder={t("allLocations")} items={locations} selected={filters.locationId} onChange={handleLocationChange} />
         </div>
         <div>
           <label className="block text-sm font-medium text-slate-700 mb-1.5">{t("department")}</label>
-          <CustomSelect placeholder={t("allDepartments")} items={departments} selected={filters.departmentId} onChange={handleDepartmentChange} />
+          <CustomSelect width placeholder={t("allDepartments")} items={departments} selected={filters.departmentId} onChange={handleDepartmentChange} />
         </div>
         <div>
           <label className="block text-sm font-medium text-slate-700 mb-1.5">{t("employee")}</label>
-          <CustomSelect placeholder={t("allEmployees")} items={employees} selected={filters.employeeId} onChange={handleEmployeeChange} />
+          <CustomSelect width placeholder={t("allEmployees")} items={employees} selected={filters.employeeId} onChange={handleEmployeeChange} />
         </div>
         <div>
           <label className="flex items-center gap-1 text-sm font-medium text-slate-700 mb-1.5">


### PR DESCRIPTION
## Improve USB Detection filter dropdown sizing

The filter dropdowns on the USB Detection page rendered at a fixed `w-44` (176px) inside wider grid cells, so they looked cramped and misaligned against the date-range picker and download buttons.

### Changes
- Pass `width` to each `CustomSelect` so it fills its grid cell (`w-full`) — clean, edge-aligned filter bar.
- Add `[&>*]:min-w-0` on the grid so cells shrink instead of overflowing/pushing neighbors.
- Add an `xl:grid-cols-3` step for a smoother `2 → 3 → 5` column progression, matching the sibling DLP pages (Screenshot Logs, Email Activity Logs).

Applies to both admin and non-admin USB Detection pages (shared component).

### Verification
- `vite build`: **passes** (exit 0).
- Verified in the running app: dropdowns are now full-width and aligned with the date range / download controls.

Frontend-only, style change; no logic/backend changes.
