### PR TITLE
fix(location-dept): SweetAlert success/error for location & department actions

### DIFF
--- a/Frontend/src/components/common/location-department/EmpLocationDepartment.jsx
+++ b/Frontend/src/components/common/location-department/EmpLocationDepartment.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import Swal from "sweetalert2";
 import { createPortal } from "react-dom";
 import {
     ChevronDown,
@@ -240,13 +241,33 @@ export default function EmpLocationDepartment() {
         loadInitialData();
     }, []);
 
-    // Auto-dismiss success message
+    // Surface store success/error via SweetAlert (add/edit/delete of locations
+    // and departments all funnel through successMsg/error), then clear the
+    // state so the same message can fire again on the next action.
     useEffect(() => {
         if (successMsg) {
-            const timer = setTimeout(clearSuccess, 4000);
-            return () => clearTimeout(timer);
+            Swal.fire({
+                icon: "success",
+                title: t("success"),
+                text: successMsg,
+                timer: 2000,
+                showConfirmButton: false,
+            });
+            clearSuccess();
         }
     }, [successMsg]);
+
+    useEffect(() => {
+        if (error) {
+            Swal.fire({
+                icon: "error",
+                title: t("error"),
+                text: error,
+                confirmButtonColor: "#ef4444",
+            });
+            clearError();
+        }
+    }, [error]);
 
     // Filter + paginate
     const filtered = useMemo(() => {
@@ -273,20 +294,6 @@ export default function EmpLocationDepartment() {
 
     return (
         <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-9 w-full">
-            {/* ── Alerts ──────────────────────────────────────────────── */}
-            {error && (
-                <div className="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700 flex items-center justify-between">
-                    <span>{error}</span>
-                    <button onClick={clearError} className="text-red-400 hover:text-red-600 text-xs ml-4">{t("locDept.dismiss")}</button>
-                </div>
-            )}
-            {successMsg && (
-                <div className="mb-4 px-4 py-3 rounded-lg bg-green-50 border border-green-200 text-sm text-green-700 flex items-center justify-between">
-                    <span>{successMsg}</span>
-                    <button onClick={clearSuccess} className="text-green-400 hover:text-green-600 text-xs ml-4">{t("locDept.dismiss")}</button>
-                </div>
-            )}
-
             {/* ── Header ─────────────────────────────────────────────── */}
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
                 <div className="flex items-center gap-3">

--- a/Frontend/src/components/common/location-department/dialog/AddDeptToLocationDialog.jsx
+++ b/Frontend/src/components/common/location-department/dialog/AddDeptToLocationDialog.jsx
@@ -77,11 +77,11 @@ const AddDeptToLocationDialog = ({ open, onOpenChange }) => {  const { t } = us
         const departmentIds = selectedDepts.filter((d) => !d.isNew).map((d) => d.id);
         const departmentNames = selectedDepts.filter((d) => d.isNew).map((d) => d.name);
 
+        // The store closes the dialog + fires a success swal on success, and an
+        // error swal on failure — only reset the local form here.
         const result = await saveAddDept({ departmentIds, departmentNames });
         if (result?.success) {
             resetForm();
-        } else {
-            setFormError(result?.message || t("locDept.failedAddDept"));
         }
     };
 

--- a/Frontend/src/components/common/location-department/dialog/AddLocationDialog.jsx
+++ b/Frontend/src/components/common/location-department/dialog/AddLocationDialog.jsx
@@ -97,10 +97,11 @@ const AddLocationDialog = ({ open, onOpenChange }) => {  const { t } = useTrans
             timezoneOffset: tz?.offset || "",
         });
 
+        // On success the store closes the dialog and fires a success swal; on
+        // failure it fires an error swal. Only reset the local form here — don't
+        // also set formError (that would double up with the store's error swal).
         if (result.success) {
             resetForm();
-        } else {
-            setFormError(result.message);
         }
     };
 

--- a/Frontend/src/components/common/location-department/dialog/EditLocationDialog.jsx
+++ b/Frontend/src/components/common/location-department/dialog/EditLocationDialog.jsx
@@ -54,16 +54,14 @@ const EditLocationDialog = ({ open, onOpenChange }) => {  const { t } = useTran
         }
         setFormError("");
 
-        const result = await saveEditLocation({
+        // The store closes the dialog + fires a success swal on success, and an
+        // error swal on failure — no local formError needed for the server result.
+        await saveEditLocation({
             locationId: editLocationData.location_id,
             name: locName.trim(),
             timezone: tz?.zone || "",
             timezoneOffset: tz?.offset || "",
         });
-
-        if (!result.success) {
-            setFormError(result.message);
-        }
     };
 
     return (


### PR DESCRIPTION
## Success / error messages on Manage Location & Department

Location and department actions (Add Location, Edit Location, Add Department, Delete) showed their result only as a small inline page banner — and **Add Location gave no clear confirmation** at all.

### Fix
All these actions funnel their result through the store's shared `successMsg` / `error` state, so I fire a centered **SweetAlert** from a single effect watching that state:
- **Success** → the server's success message (auto-dismisses after 2s).
- **Error** → error alert with the server's message.

Because it's centralized, **every** location/department action gets the swal, not just Add Location.

The dialogs no longer also set a local `formError` from the server result (that would double up with the store's error swal); client-side validation errors still show inline in each dialog. Removed the now-unused inline page banners.

### Verification
- `vite build`: **passes** (exit 0).
- No new lint errors from these changes (the pre-existing `refs during render` and edit-populate `set-state-in-effect` notices are on untouched code).
- Verified in the running app: adding a location shows a centered success popup.

Frontend-only; no backend/deploy changes.
