### PR TITLE
fix(productivity-tab): stop double-counting productivity percentage

### DIFF
--- a/Frontend/src/page/protected/admin/employee-profile/ProductivityTab.jsx
+++ b/Frontend/src/page/protected/admin/employee-profile/ProductivityTab.jsx
@@ -207,7 +207,10 @@ export default function ProductivityTab({ employee, startDate, endDate }) {
 
   const totalUnproductive = days.reduce((s, d) => s + (d.non_productive_duration ?? 0), 0);
   const totalNeutral      = days.reduce((s, d) => s + (d.neutral_duration        ?? 0), 0);
-  const productivityPct   = totals ? `${(totals.total_productivity * 100).toFixed(2)}%` : "—";
+  // total_productivity already arrives as a percentage from the backend
+  // ((productive / custom_time) * 100, and capped at 100 for capping orgs). The
+  // extra * 100 here double-counted it (e.g. 9.19 → 919.32%). Use it directly.
+  const productivityPct   = totals ? `${(Number(totals.total_productivity) || 0).toFixed(2)}%` : "—";
 
   const statCards = [
     {


### PR DESCRIPTION
## Fix Productivity showing 919.32%

The Productivity stat card on the employee Productivity tab displayed impossible values like **919.32%**.

### Root cause — double multiplication
The backend (`Productivity.controller.js`) already returns `total_productivity` **as a percentage**:
```js
total_productivity: (total_productive_duration / total_custom_time) * 100   // and capped at 100 for "capping" orgs
```
But the frontend (`ProductivityTab.jsx`) multiplied it by **100 again**:
```js
`${(totals.total_productivity * 100).toFixed(2)}%`
```
So a real **9.19%** became `9.1932 × 100 = 919.32%`.

### Fix
Use the backend value directly (no re-scaling):
```js
`${(Number(totals.total_productivity) || 0).toFixed(2)}%`
```
Deliberately **not** clamped to 100% — the backend only caps for specific capping-enabled orgs, so a legitimately >100% value (worked more than expected time) still displays faithfully for other orgs. The change is purely removing the erroneous extra `× 100`.

### Verification
- `vite build`: **passes** (exit 0).
- Confirmed no other place in the codebase repeats the `total_productivity * 100` mistake.
- Verified in the running app: the Productivity card now shows a sane percentage instead of 919.32%.

Frontend-only; no backend/deploy changes.
