### PR TITLE
fix(roles): SweetAlert success/error for role & permission actions

### DIFF
--- a/Frontend/src/components/common/roles-permission/EmpRolesPermisssion.jsx
+++ b/Frontend/src/components/common/roles-permission/EmpRolesPermisssion.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import Swal from "sweetalert2";
 import {
     Search,
     Plus,
@@ -198,13 +199,33 @@ const EmpRolesPermission = () => {
         loadInitialData();
     }, []);
 
-    // Auto-dismiss success message
+    // Surface store success/error via SweetAlert (add / edit / clone / delete of
+    // roles all funnel through successMsg/error), then clear the state so the
+    // same message can fire again on the next action.
     useEffect(() => {
         if (successMsg) {
-            const timer = setTimeout(clearSuccess, 4000);
-            return () => clearTimeout(timer);
+            Swal.fire({
+                icon: "success",
+                title: t("success"),
+                text: successMsg,
+                timer: 2000,
+                showConfirmButton: false,
+            });
+            clearSuccess();
         }
     }, [successMsg]);
+
+    useEffect(() => {
+        if (error) {
+            Swal.fire({
+                icon: "error",
+                title: t("error"),
+                text: error,
+                confirmButtonColor: "#ef4444",
+            });
+            clearError();
+        }
+    }, [error]);
 
     const serverTotalPages = Math.max(1, Math.ceil(totalCount / pagination.pageSize));
     const debouncedSearch = useDebounce((val) => setSearch(val), 300);
@@ -215,19 +236,6 @@ const EmpRolesPermission = () => {
 
     return (
         <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-9 w-full">
-            {/* ── Alerts ──────────────────────────────────────────────── */}
-            {error && (
-                <div className="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700 flex items-center justify-between">
-                    <span>{error}</span>
-                    <button onClick={clearError} className="text-red-400 hover:text-red-600 text-xs ml-4">{t("roles.dismiss")}</button>
-                </div>
-            )}
-            {successMsg && (
-                <div className="mb-4 px-4 py-3 rounded-lg bg-green-50 border border-green-200 text-sm text-green-700 flex items-center justify-between">
-                    <span>{successMsg}</span>
-                    <button onClick={clearSuccess} className="text-green-400 hover:text-green-600 text-xs ml-4">{t("roles.dismiss")}</button>
-                </div>
-            )}
 
             {/* ── Header ─────────────────────────────────────────────── */}
             <div className="flex flex-wrap items-start justify-between gap-4 mb-6">

--- a/Frontend/src/components/common/roles-permission/dialog/AddRoleDialog.jsx
+++ b/Frontend/src/components/common/roles-permission/dialog/AddRoleDialog.jsx
@@ -74,6 +74,9 @@ const AddRoleDialog = ({ open, onOpenChange }) => {
         }
         setFormError("");
 
+        // The store closes the dialog + fires a success swal on success, and an
+        // error swal on failure — only reset the local form here (don't also set
+        // formError, which would double up with the store's error swal).
         const result = await saveRole({
             name: roleName.trim(),
             locationDept: locationDeptRows,
@@ -82,8 +85,6 @@ const AddRoleDialog = ({ open, onOpenChange }) => {
 
         if (result?.success) {
             resetForm();
-        } else if (result?.message) {
-            setFormError(result.message);
         }
     };
 

--- a/Frontend/src/components/common/roles-permission/dialog/CloneRoleDialog.jsx
+++ b/Frontend/src/components/common/roles-permission/dialog/CloneRoleDialog.jsx
@@ -37,11 +37,11 @@ const CloneRoleDialog = ({ open, onOpenChange }) => {
         }
         setFormError("");
 
+        // Store closes the dialog + fires a success swal on success, error swal
+        // on failure — only reset the local form here.
         const result = await confirmCloneRole(newName.trim());
         if (result?.success) {
             resetForm();
-        } else if (result?.message) {
-            setFormError(result.message);
         }
     };
 

--- a/Frontend/src/components/common/roles-permission/dialog/EditRoleDialog.jsx
+++ b/Frontend/src/components/common/roles-permission/dialog/EditRoleDialog.jsx
@@ -144,10 +144,10 @@ const EditRoleDialog = ({ open, onOpenChange }) => {
             permission: editRoleData.permission,
         });
 
+        // Store closes the dialog + fires a success swal on success, error swal
+        // on failure — only reset the local form here.
         if (result?.success) {
             resetForm();
-        } else if (result?.message) {
-            setFormError(result.message);
         }
     };
 

--- a/Frontend/src/components/common/roles-permission/dialog/PermissionSettingsDialog.jsx
+++ b/Frontend/src/components/common/roles-permission/dialog/PermissionSettingsDialog.jsx
@@ -122,9 +122,7 @@ const PermissionSettingsDialog = ({ open, onOpenChange }) => {
                 icon: "success",
                 title: "Permissions saved",
                 text: result.message || `Permissions updated for ${permissionRoleData.name}.`,
-                toast: true,
-                position: "top-end",
-                timer: 2500,
+                timer: 2000,
                 showConfirmButton: false,
             });
         } else {


### PR DESCRIPTION
## Success / error messages on Roles & Permissions

Role actions (Add Role, Edit Role, Clone, Delete) showed their result only as a small inline page banner — and **Add Role gave no clear confirmation** at all.

### Fix
These actions funnel their result through the store's shared `successMsg` / `error` state, so I fire a centered **SweetAlert** from a single effect watching that state:
- **Success** → the server's message (auto-dismisses after 2s).
- **Error** → error alert with the server's message.

Because it's centralized, **every** role action gets the swal, not just Add Role.

Removed the redundant per-dialog `setFormError(result.message)` so server errors don't double up with the store swal; client-side validation errors still show inline in each dialog. Removed the now-unused inline page banners.

Also made the **PermissionSettingsDialog** success alert a centered swal (it was a `toast: true` top-end toast) so all role/permission feedback is consistent.

### Verification
- `vite build`: **passes** (exit 0).
- No new lint errors from these changes (the pre-existing `useEffect` unused import in AddRoleDialog and `set-state-in-effect`/`refs` notices are on untouched code).
- Verified in the running app: Add Role and permission update both show a centered success popup.

Frontend-only; no backend/deploy changes.
