### PR TITLE
Bugfix allow cross-origin embedding of proxied screenshots

### DIFF
--- a/Backend/admin/src/App.js
+++ b/Backend/admin/src/App.js
@@ -110,8 +110,13 @@ class App {
                 stream: stream
             }))
         }
-        // Added security headers
-        app.use(helmet());
+        // Added security headers.
+        // crossOriginResourcePolicy is relaxed to "cross-origin" because this API
+        // serves media (e.g. /api/v3/*-http-proxy screenshots) that the frontend
+        // embeds via <img> from a different origin. Helmet's default of
+        // "same-origin" makes the browser block those embeds with
+        // ERR_BLOCKED_BY_RESPONSE.NotSameOrigin even though the request returns 200.
+        app.use(helmet({ crossOriginResourcePolicy: { policy: 'cross-origin' } }));
 
         // handling DDOS attacks by stopeing req after specified time with specific req calls
         // app.use(new rateLimit({ windowMs: parseInt(process.env.RATE_LIMIT_DURATION) * 60 * 1000, max: parseInt(process.env.RATE_LIMIT_REQUEST_ALLOWED) }));


### PR DESCRIPTION
Helmet's default Cross-Origin-Resource-Policy of "same-origin" caused the browser to block the admin frontend from embedding screenshots served by /api/v3/*-http-proxy via <img>, failing with
ERR_BLOCKED_BY_RESPONSE.NotSameOrigin (request returned 200 but was not handed to the page). Relax CORP to "cross-origin" so cross-origin media embeds are permitted.